### PR TITLE
Update TopoFlow components

### DIFF
--- a/.bmi.yaml
+++ b/.bmi.yaml
@@ -1,5 +1,22 @@
 bmi_paths:
+  - .bmi/channels_kinematic_wave
+  - .bmi/channels_diffusive_wave
+  - .bmi/channels_dynamic_wave
+  - .bmi/diversions_fraction_method
+  - .bmi/diversions_standard
+  - .bmi/evap_energy_balance
+  - .bmi/evap_priestley_taylor
+  - .bmi/evap_read_file
   - .bmi/ice_gc2d
+  - .bmi/infil_beven
+  - .bmi/infil_green_ampt
+  - .bmi/infil_richards_1d
+  - .bmi/infil_smith_parlange
+  - .bmi/meteorology
+  - .bmi/satzone_darcy_layers
+  - .bmi/snow_degree_day
+  - .bmi/snow_energy_balance
+  - .bmi/topoflow
 
 build:
   - python setup.py develop

--- a/.bmi/channels_diffusive_wave/Channels_Diffusive_Wave.cfg.in
+++ b/.bmi/channels_diffusive_wave/Channels_Diffusive_Wave.cfg.in
@@ -1,0 +1,57 @@
+#===============================================================================
+# Topoflow Config File for: channels_diffusive_wave
+#===============================================================================
+# Input 1
+comp_status         | Enabled             | choice    | Component status [-] {Enabled; Disabled}
+in_directory        | {in_directory}      | string    | Input directory [-]
+out_directory       | {out_directory}     | string    | Output directory [-]
+site_prefix         | {site_prefix}       | string    | File prefix for the study site [-]
+case_prefix         | {case_prefix}       | string    | File prefix for the model scenario [-]
+n_steps             | {n_steps}           | long      | Number of time steps [-]
+dt                  | {dt}                | float     | Channel process timestep [sec]
+code_file           | {code_file}         | string    | Grid of d8 flow codes in binary file (jenson 84) [-]
+slope_file          | {slope_file}        | string    | Grid of d8 slopes in binary file [m/m]
+MANNING             | {MANNING}           | int       | Option to use manning's n for roughness [-]
+LAW_OF_WALL         | {LAW_OF_WALL}       | int       | Option to use law of wall for roughness [-]
+nval_type           | {nval_type}         | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+nval                | {nval}              | string    | Manning's n values [s/m^(1/3)]
+z0val_type          | {z0val_type}        | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+z0val               | {z0val}             | string    | Law-of-wall roughness values [m]
+#===============================================================================
+# Input 2
+width_type          | {width_type}        | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+width               | {width}             | string    | Bottom width of trapezoid cross-section [m]
+angle_type          | {angle_type}        | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+angle               | {angle}             | string    | Bank angle of trapezoid cross-section [deg]
+d0_type             | {d0_type}           | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+d0                  | {d0}                | float     | Initial flow depth (if scalar, use 0.0!) [m]
+sinu_type           | {sinu_type}         | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+sinu                | {sinu}              | float     | Absolute channel sinuosity [m/m]
+#===============================================================================
+# Output 1
+save_grid_dt        | {save_grid_dt}      | float     | Time interval between saved grids [sec]
+SAVE_Q_GRIDS        | {SAVE_Q_GRIDS}      | choice    | Option to save computed q grids [-] {Yes; No}
+Q_gs_file           | {Q_gs_file}         | string    | Filename for q grid stack [m^3/s]
+SAVE_U_GRIDS        | {SAVE_U_GRIDS}      | choice    | Option to save computed u grids [-] {Yes; No}
+u_gs_file           | {u_gs_file}         | string    | Filename for u grid stack [m/s]
+SAVE_D_GRIDS        | {SAVE_D_GRIDS}      | choice    | Option to save computed d grids [-] {Yes; No}
+d_gs_file           | {d_gs_file}         | string    | Filename for d grid stack [m]
+SAVE_F_GRIDS        | {SAVE_F_GRIDS}      | choice    | Option to save computed f grids [-] {Yes; No}
+f_gs_file           | {f_gs_file}         | string    | Filename for f grid stack [-]
+#===============================================================================
+# Output 2
+save_pixels_dt      | {save_pixels_dt}    | float     | Time interval between time series values [sec]
+pixel_file          | {pixel_file}        | string    | Filename for monitored pixel file [-]
+SAVE_Q_PIXELS       | {SAVE_Q_PIXELS}     | choice    | Option to save computed q time series [-] {Yes; No}
+Q_ts_file           | {Q_ts_file}         | string    | Filename for computed q time series [m^3/s]
+SAVE_U_PIXELS       | {SAVE_U_PIXELS}     | choice    | Option to save computed u time series [-] {Yes; No}
+u_ts_file           | {u_ts_file}         | string    | Filename for computed u time series [m/s]
+SAVE_D_PIXELS       | {SAVE_D_PIXELS}     | choice    | Option to save computed d time series [-] {Yes; No}
+d_ts_file           | {d_ts_file}         | string    | Filename for computed d time series [m]
+SAVE_F_PIXELS       | {SAVE_F_PIXELS}     | choice    | Option to save computed f time series [-] {Yes; No}
+f_ts_file           | {f_ts_file}         | string    | Filename for computed f time series [-]
+#===============================================================================
+# About
+ModelName           | {ModelName}         | String    | Name of the model [-]
+ModelAuthor         | {ModelAuthor}       | String    | Name of the model author [-]
+HTML_HELP_FILE      | {HTML_HELP_FILE}    | String    | Url for html help file [-]

--- a/.bmi/channels_diffusive_wave/api.yaml
+++ b/.bmi/channels_diffusive_wave/api.yaml
@@ -1,0 +1,5 @@
+name: ChannelsDiffWave
+language: python
+
+package: topoflow.components.channels_diffusive_wave
+class: channels_component

--- a/.bmi/channels_diffusive_wave/info.yaml
+++ b/.bmi/channels_diffusive_wave/info.yaml
@@ -1,0 +1,4 @@
+url: https://github.com/peckhams/topoflow
+author: Scott Peckham
+email: scott.peckham@colorado.edu
+version: 3.1.0

--- a/.bmi/channels_diffusive_wave/parameters.yaml
+++ b/.bmi/channels_diffusive_wave/parameters.yaml
@@ -1,0 +1,23 @@
+%YAML 1.2
+---
+run_duration:
+  description: Simulation run time
+  value:
+    type: int
+    default: 1
+    units: d
+    range:
+      max: 1000000
+      min: 0
+site_prefix:
+  description: File prefix for the study site
+  value:
+    type: string
+    default: Treynor
+    units: '-'
+case_prefix:
+  description: File prefix for the model scenario
+  value:
+    type: string
+    default: Case5
+    units: '-'

--- a/.bmi/channels_dynamic_wave/Channels_Dynamic_Wave.cfg.in
+++ b/.bmi/channels_dynamic_wave/Channels_Dynamic_Wave.cfg.in
@@ -1,0 +1,57 @@
+#===============================================================================
+# Topoflow Config File for: channels_dynamic_wave
+#===============================================================================
+# Input 1
+comp_status         | Enabled             | choice    | Component status [-] {Enabled; Disabled}
+in_directory        | {in_directory}      | string    | Input directory [-]
+out_directory       | {out_directory}     | string    | Output directory [-]
+site_prefix         | {site_prefix}       | string    | File prefix for the study site [-]
+case_prefix         | {case_prefix}       | string    | File prefix for the model scenario [-]
+n_steps             | {n_steps}           | long      | Number of time steps [-]
+dt                  | {dt}                | float     | Channel process timestep [sec]
+code_file           | {code_file}         | string    | Grid of d8 flow codes in binary file (jenson 84) [-]
+slope_file          | {slope_file}        | string    | Grid of d8 slopes in binary file [m/m]
+MANNING             | {MANNING}           | int       | Option to use manning's n for roughness [-]
+LAW_OF_WALL         | {LAW_OF_WALL}       | int       | Option to use law of wall for roughness [-]
+nval_type           | {nval_type}         | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+nval                | {nval}              | string    | Manning's n values [s/m^(1/3)]
+z0val_type          | {z0val_type}        | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+z0val               | {z0val}             | string    | Law-of-wall roughness values [m]
+#===============================================================================
+# Input 2
+width_type          | {width_type}        | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+width               | {width}             | string    | Bottom width of trapezoid cross-section [m]
+angle_type          | {angle_type}        | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+angle               | {angle}             | string    | Bank angle of trapezoid cross-section [deg]
+d0_type             | {d0_type}           | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+d0                  | {d0}                | float     | Initial flow depth (if scalar, use 0.0!) [m]
+sinu_type           | {sinu_type}         | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+sinu                | {sinu}              | float     | Absolute channel sinuosity [m/m]
+#===============================================================================
+# Output 1
+save_grid_dt        | {save_grid_dt}      | float     | Time interval between saved grids [sec]
+SAVE_Q_GRIDS        | {SAVE_Q_GRIDS}      | choice    | Option to save computed q grids [-] {Yes; No}
+Q_gs_file           | {Q_gs_file}         | string    | Filename for q grid stack [m^3/s]
+SAVE_U_GRIDS        | {SAVE_U_GRIDS}      | choice    | Option to save computed u grids [-] {Yes; No}
+u_gs_file           | {u_gs_file}         | string    | Filename for u grid stack [m/s]
+SAVE_D_GRIDS        | {SAVE_D_GRIDS}      | choice    | Option to save computed d grids [-] {Yes; No}
+d_gs_file           | {d_gs_file}         | string    | Filename for d grid stack [m]
+SAVE_F_GRIDS        | {SAVE_F_GRIDS}      | choice    | Option to save computed f grids [-] {Yes; No}
+f_gs_file           | {f_gs_file}         | string    | Filename for f grid stack [-]
+#===============================================================================
+# Output 2
+save_pixels_dt      | {save_pixels_dt}    | float     | Time interval between time series values [sec]
+pixel_file          | {pixel_file}        | string    | Filename for monitored pixel file [-]
+SAVE_Q_PIXELS       | {SAVE_Q_PIXELS}     | choice    | Option to save computed q time series [-] {Yes; No}
+Q_ts_file           | {Q_ts_file}         | string    | Filename for computed q time series [m^3/s]
+SAVE_U_PIXELS       | {SAVE_U_PIXELS}     | choice    | Option to save computed u time series [-] {Yes; No}
+u_ts_file           | {u_ts_file}         | string    | Filename for computed u time series [m/s]
+SAVE_D_PIXELS       | {SAVE_D_PIXELS}     | choice    | Option to save computed d time series [-] {Yes; No}
+d_ts_file           | {d_ts_file}         | string    | Filename for computed d time series [m]
+SAVE_F_PIXELS       | {SAVE_F_PIXELS}     | choice    | Option to save computed f time series [-] {Yes; No}
+f_ts_file           | {f_ts_file}         | string    | Filename for computed f time series [-]
+#===============================================================================
+# About
+ModelName           | {ModelName}         | String    | Name of the model [-]
+ModelAuthor         | {ModelAuthor}       | String    | Name of the model author [-]
+HTML_HELP_FILE      | {HTML_HELP_FILE}    | String    | Url for html help file [-]

--- a/.bmi/channels_dynamic_wave/api.yaml
+++ b/.bmi/channels_dynamic_wave/api.yaml
@@ -1,0 +1,5 @@
+name: ChannelsDynamWave
+language: python
+
+package: topoflow.components.channels_dynamic_wave
+class: channels_component

--- a/.bmi/channels_dynamic_wave/info.yaml
+++ b/.bmi/channels_dynamic_wave/info.yaml
@@ -1,0 +1,4 @@
+url: https://github.com/peckhams/topoflow
+author: Scott Peckham
+email: scott.peckham@colorado.edu
+version: 3.1.0

--- a/.bmi/channels_dynamic_wave/parameters.yaml
+++ b/.bmi/channels_dynamic_wave/parameters.yaml
@@ -1,0 +1,23 @@
+%YAML 1.2
+---
+run_duration:
+  description: Simulation run time
+  value:
+    type: int
+    default: 1
+    units: d
+    range:
+      max: 1000000
+      min: 0
+site_prefix:
+  description: File prefix for the study site
+  value:
+    type: string
+    default: Treynor
+    units: '-'
+case_prefix:
+  description: File prefix for the model scenario
+  value:
+    type: string
+    default: Case5
+    units: '-'

--- a/.bmi/channels_kinematic_wave/Channels_Kinematic_Wave.cfg.in
+++ b/.bmi/channels_kinematic_wave/Channels_Kinematic_Wave.cfg.in
@@ -1,0 +1,57 @@
+#===============================================================================
+# Topoflow Config File for: channels_kinematic_wave
+#===============================================================================
+# Input 1
+comp_status         | Enabled             | choice    | Component status [-] {Enabled; Disabled}
+in_directory        | {in_directory}      | string    | Input directory [-]
+out_directory       | {out_directory}     | string    | Output directory [-]
+site_prefix         | {site_prefix}       | string    | File prefix for the study site [-]
+case_prefix         | {case_prefix}       | string    | File prefix for the model scenario [-]
+n_steps             | {n_steps}           | long      | Number of time steps [-]
+dt                  | {dt}                | float     | Channel process timestep [sec]
+code_file           | {code_file}         | string    | Grid of d8 flow codes in binary file (jenson 84) [-]
+slope_file          | {slope_file}        | string    | Grid of d8 slopes in binary file [m/m]
+MANNING             | {MANNING}           | int       | Option to use manning's n for roughness [-]
+LAW_OF_WALL         | {LAW_OF_WALL}       | int       | Option to use law of wall for roughness [-]
+nval_type           | {nval_type}         | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+nval                | {nval}              | string    | Manning's n values [s/m^(1/3)]
+z0val_type          | {z0val_type}        | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+z0val               | {z0val}             | string    | Law-of-wall roughness values [m]
+#===============================================================================
+# Input 2
+width_type          | {width_type}        | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+width               | {width}             | string    | Bottom width of trapezoid cross-section [m]
+angle_type          | {angle_type}        | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+angle               | {angle}             | string    | Bank angle of trapezoid cross-section [deg]
+d0_type             | {d0_type}           | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+d0                  | {d0}                | float     | Initial flow depth (if scalar, use 0.0!) [m]
+sinu_type           | {sinu_type}         | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+sinu                | {sinu}              | float     | Absolute channel sinuosity [m/m]
+#===============================================================================
+# Output 1
+save_grid_dt        | {save_grid_dt}      | float     | Time interval between saved grids [sec]
+SAVE_Q_GRIDS        | {SAVE_Q_GRIDS}      | choice    | Option to save computed q grids [-] {Yes; No}
+Q_gs_file           | {Q_gs_file}         | string    | Filename for q grid stack [m^3/s]
+SAVE_U_GRIDS        | {SAVE_U_GRIDS}      | choice    | Option to save computed u grids [-] {Yes; No}
+u_gs_file           | {u_gs_file}         | string    | Filename for u grid stack [m/s]
+SAVE_D_GRIDS        | {SAVE_D_GRIDS}      | choice    | Option to save computed d grids [-] {Yes; No}
+d_gs_file           | {d_gs_file}         | string    | Filename for d grid stack [m]
+SAVE_F_GRIDS        | {SAVE_F_GRIDS}      | choice    | Option to save computed f grids [-] {Yes; No}
+f_gs_file           | {f_gs_file}         | string    | Filename for f grid stack [-]
+#===============================================================================
+# Output 2
+save_pixels_dt      | {save_pixels_dt}    | float     | Time interval between time series values [sec]
+pixel_file          | {pixel_file}        | string    | Filename for monitored pixel file [-]
+SAVE_Q_PIXELS       | {SAVE_Q_PIXELS}     | choice    | Option to save computed q time series [-] {Yes; No}
+Q_ts_file           | {Q_ts_file}         | string    | Filename for computed q time series [m^3/s]
+SAVE_U_PIXELS       | {SAVE_U_PIXELS}     | choice    | Option to save computed u time series [-] {Yes; No}
+u_ts_file           | {u_ts_file}         | string    | Filename for computed u time series [m/s]
+SAVE_D_PIXELS       | {SAVE_D_PIXELS}     | choice    | Option to save computed d time series [-] {Yes; No}
+d_ts_file           | {d_ts_file}         | string    | Filename for computed d time series [m]
+SAVE_F_PIXELS       | {SAVE_F_PIXELS}     | choice    | Option to save computed f time series [-] {Yes; No}
+f_ts_file           | {f_ts_file}         | string    | Filename for computed f time series [-]
+#===============================================================================
+# About
+ModelName           | {ModelName}         | String    | Name of the model [-]
+ModelAuthor         | {ModelAuthor}       | String    | Name of the model author [-]
+HTML_HELP_FILE      | {HTML_HELP_FILE}    | String    | Url for html help file [-]

--- a/.bmi/channels_kinematic_wave/api.yaml
+++ b/.bmi/channels_kinematic_wave/api.yaml
@@ -1,0 +1,5 @@
+name: ChannelsKinWave
+language: python
+
+package: topoflow.components.channels_kinematic_wave
+class: channels_component

--- a/.bmi/channels_kinematic_wave/info.yaml
+++ b/.bmi/channels_kinematic_wave/info.yaml
@@ -1,0 +1,4 @@
+url: https://github.com/peckhams/topoflow
+author: Scott Peckham
+email: scott.peckham@colorado.edu
+version: 3.1.0

--- a/.bmi/channels_kinematic_wave/parameters.yaml
+++ b/.bmi/channels_kinematic_wave/parameters.yaml
@@ -1,0 +1,23 @@
+%YAML 1.2
+---
+run_duration:
+  description: Simulation run time
+  value:
+    type: int
+    default: 1
+    units: d
+    range:
+      max: 1000000
+      min: 0
+site_prefix:
+  description: File prefix for the study site
+  value:
+    type: string
+    default: Treynor
+    units: '-'
+case_prefix:
+  description: File prefix for the model scenario
+  value:
+    type: string
+    default: Case5
+    units: '-'

--- a/.bmi/diversions_fraction_method/Diversions_Fraction_Method.cfg.in
+++ b/.bmi/diversions_fraction_method/Diversions_Fraction_Method.cfg.in
@@ -1,0 +1,20 @@
+#===============================================================================
+# Topoflow Config File for: diversions_fraction_method
+#===============================================================================
+# Input
+comp_status         | Enabled             | choice    | Component status [-] {Enabled; Disabled}
+in_directory        | {in_directory}      | string    | Input directory [-]
+out_directory       | {out_directory}     | string    | Output directory [-]
+site_prefix         | {site_prefix}       | string    | File prefix for the study site [-]
+case_prefix         | {case_prefix}       | string    | File prefix for the model scenario [-]
+use_sources         | {use_sources}       | choice    | Option to use sources [-] {Yes; No}
+source_file         | {source_file}       | string    | Source information file [-]
+use_sinks           | {use_sinks}         | choice    | Option to use sinks [-] {Yes; No}
+sink_file           | {sink_file}         | string    | Sink information file [-]
+use_canals          | {use_canals}        | choice    | Option to use canals [-] {Yes; No}
+canal_file          | {canal_file}        | string    | Canal information file [-]
+#===============================================================================
+# About
+ModelName           | {ModelName}         | String    | Name of the model [-]
+ModelAuthor         | {ModelAuthor}       | String    | Name of the model author [-]
+HTML_HELP_FILE      | {HTML_HELP_FILE}    | String    | Url for html help file [-]

--- a/.bmi/diversions_fraction_method/api.yaml
+++ b/.bmi/diversions_fraction_method/api.yaml
@@ -1,0 +1,5 @@
+name: DiversionsFraction
+language: python
+
+package: topoflow.components.diversions_fraction_method
+class: diversions_component

--- a/.bmi/diversions_fraction_method/info.yaml
+++ b/.bmi/diversions_fraction_method/info.yaml
@@ -1,0 +1,4 @@
+url: https://github.com/peckhams/topoflow
+author: Scott Peckham
+email: scott.peckham@colorado.edu
+version: 3.1.0

--- a/.bmi/diversions_fraction_method/parameters.yaml
+++ b/.bmi/diversions_fraction_method/parameters.yaml
@@ -1,0 +1,23 @@
+%YAML 1.2
+---
+run_duration:
+  description: Simulation run time
+  value:
+    type: int
+    default: 1
+    units: d
+    range:
+      max: 1000000
+      min: 0
+site_prefix:
+  description: File prefix for the study site
+  value:
+    type: string
+    default: Treynor
+    units: '-'
+case_prefix:
+  description: File prefix for the model scenario
+  value:
+    type: string
+    default: Case5
+    units: '-'

--- a/.bmi/diversions_standard/Diversions_Standard.cfg.in
+++ b/.bmi/diversions_standard/Diversions_Standard.cfg.in
@@ -1,0 +1,20 @@
+#===============================================================================
+# Topoflow Config File for: diversions_standard
+#===============================================================================
+# Input
+comp_status         | Enabled             | choice    | Component status [-] {Enabled; Disabled}
+in_directory        | {in_directory}      | string    | Input directory [-]
+out_directory       | {out_directory}     | string    | Output directory [-]
+site_prefix         | {site_prefix}       | string    | File prefix for the study site [-]
+case_prefix         | {case_prefix}       | string    | File prefix for the model scenario [-]
+use_sources         | {use_sources}       | choice    | Option to use sources [-] {Yes; No}
+source_file         | {source_file}       | string    | Source information file [-]
+use_sinks           | {use_sinks}         | choice    | Option to use sinks [-] {Yes; No}
+sink_file           | {sink_file}         | string    | Sink information file [-]
+use_canals          | {use_canals}        | choice    | Option to use canals [-] {Yes; No}
+canal_file          | {canal_file}        | string    | Canal information file [-]
+#===============================================================================
+# About
+ModelName           | {ModelName}         | String    | Name of the model [-]
+ModelAuthor         | {ModelAuthor}       | String    | Name of the model author [-]
+HTML_HELP_FILE      | {HTML_HELP_FILE}    | String    | Url for html help file [-]

--- a/.bmi/diversions_standard/api.yaml
+++ b/.bmi/diversions_standard/api.yaml
@@ -1,0 +1,5 @@
+name: Diversions
+language: python
+
+package: topoflow.components.diversions_base
+class: diversions_component

--- a/.bmi/diversions_standard/info.yaml
+++ b/.bmi/diversions_standard/info.yaml
@@ -1,0 +1,4 @@
+url: https://github.com/peckhams/topoflow
+author: Scott Peckham
+email: scott.peckham@colorado.edu
+version: 3.1.0

--- a/.bmi/diversions_standard/parameters.yaml
+++ b/.bmi/diversions_standard/parameters.yaml
@@ -1,0 +1,23 @@
+%YAML 1.2
+---
+run_duration:
+  description: Simulation run time
+  value:
+    type: int
+    default: 1
+    units: d
+    range:
+      max: 1000000
+      min: 0
+site_prefix:
+  description: File prefix for the study site
+  value:
+    type: string
+    default: Treynor
+    units: '-'
+case_prefix:
+  description: File prefix for the model scenario
+  value:
+    type: string
+    default: Case5
+    units: '-'

--- a/.bmi/evap_energy_balance/Evap_Energy_Balance.cfg.in
+++ b/.bmi/evap_energy_balance/Evap_Energy_Balance.cfg.in
@@ -1,0 +1,31 @@
+#===============================================================================
+# Topoflow Config File for: evap_energy_balance
+#===============================================================================
+# Input
+comp_status         | Enabled             | choice    | Component status [-] {Enabled; Disabled}
+in_directory        | {in_directory}      | string    | Input directory [-]
+out_directory       | {out_directory}     | string    | Output directory [-]
+site_prefix         | {site_prefix}       | string    | File prefix for the study site [-]
+case_prefix         | {case_prefix}       | string    | File prefix for the model scenario [-]
+n_steps             | {n_steps}           | long      | Number of time steps [-]
+dt                  | {dt}                | float     | Evaporation process timestep [sec]
+K_soil_type         | {K_soil_type}       | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+K_soil              | {K_soil}            | float     | Thermal conductivity of soil [W/m/deg_C]
+soil_x_type         | {soil_x_type}       | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+soil_x              | {soil_x}            | float     | Reference depth in soil [m]
+T_soil_x_type       | {T_soil_x_type}     | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+T_soil_x            | {T_soil_x}          | float     | Temperature of soil at depth x [degC]
+#===============================================================================
+# Output
+save_grid_dt        | {save_grid_dt}      | float     | Time interval between saved grids [sec]
+SAVE_ER_GRIDS       | {SAVE_ER_GRIDS}     | choice    | Option to save grids of evap. rate [mm/hr] {Yes; No}
+er_gs_file          | {er_gs_file}        | string    | Filename for grid stack of evap. rate [mm/hr]
+save_pixels_dt      | {save_pixels_dt}    | float     | Time interval between time series values [sec]
+pixel_file          | {pixel_file}        | string    | Filename for monitored pixel file [-]
+SAVE_ER_PIXELS      | {SAVE_ER_PIXELS}    | choice    | Option to save time series of evap. rate [-] {Yes; No}
+er_ts_file          | {er_ts_file}        | string    | Filename for time series of evap. rate [mm/hr]
+#===============================================================================
+# About
+ModelName           | {ModelName}         | String    | Name of the model [-]
+ModelAuthor         | {ModelAuthor}       | String    | Name of the model author [-]
+HTML_HELP_FILE      | {HTML_HELP_FILE}    | String    | Url for html help file [-]

--- a/.bmi/evap_energy_balance/api.yaml
+++ b/.bmi/evap_energy_balance/api.yaml
@@ -1,0 +1,5 @@
+name: EvapEnergyBalance
+language: python
+
+package: topoflow.components.evap_energy_balance
+class: evap_component

--- a/.bmi/evap_energy_balance/info.yaml
+++ b/.bmi/evap_energy_balance/info.yaml
@@ -1,0 +1,4 @@
+url: https://github.com/peckhams/topoflow
+author: Scott Peckham
+email: scott.peckham@colorado.edu
+version: 3.1.0

--- a/.bmi/evap_energy_balance/parameters.yaml
+++ b/.bmi/evap_energy_balance/parameters.yaml
@@ -1,0 +1,23 @@
+%YAML 1.2
+---
+run_duration:
+  description: Simulation run time
+  value:
+    type: int
+    default: 1
+    units: d
+    range:
+      max: 1000000
+      min: 0
+site_prefix:
+  description: File prefix for the study site
+  value:
+    type: string
+    default: Treynor
+    units: '-'
+case_prefix:
+  description: File prefix for the model scenario
+  value:
+    type: string
+    default: Case5
+    units: '-'

--- a/.bmi/evap_priestley_taylor/Evap_Priestley_Taylor.cfg.in
+++ b/.bmi/evap_priestley_taylor/Evap_Priestley_Taylor.cfg.in
@@ -1,0 +1,33 @@
+#===============================================================================
+# Topoflow Config File for: evap_priestley_taylor
+#===============================================================================
+# Input
+comp_status         | Enabled             | choice    | Component status [-] {Enabled; Disabled}
+in_directory        | {in_directory}      | string    | Input directory [-]
+out_directory       | {out_directory}     | string    | Output directory [-]
+site_prefix         | {site_prefix}       | string    | File prefix for the study site [-]
+case_prefix         | {case_prefix}       | string    | File prefix for the model scenario [-]
+n_steps             | {n_steps}           | long      | Number of time steps [-]
+dt                  | {dt}                | float     | Evaporation process timestep [sec]
+alpha_type          | {alpha_type}        | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+alpha               | {alpha}             | float     | Coefficient [-]
+K_soil_type         | {K_soil_type}       | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+K_soil              | {K_soil}            | float     | Thermal conductivity of soil [W/m/deg_C]
+soil_x_type         | {soil_x_type}       | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+soil_x              | {soil_x}            | float     | Reference depth in soil [m]
+T_soil_x_type       | {T_soil_x_type}     | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+T_soil_x            | {T_soil_x}          | float     | Temperature of soil at depth x [degC]
+#===============================================================================
+# Output
+save_grid_dt        | {save_grid_dt}      | float     | Time interval between saved grids [sec]
+SAVE_ER_GRIDS       | {SAVE_ER_GRIDS}     | choice    | Option to save grids of evap. rate [mm/hr] {Yes; No}
+er_gs_file          | {er_gs_file}        | string    | Filename for grid stack of evap. rate [mm/hr]
+save_pixels_dt      | {save_pixels_dt}    | float     | Time interval between time series values [sec]
+pixel_file          | {pixel_file}        | string    | Filename for monitored pixel file [-]
+SAVE_ER_PIXELS      | {SAVE_ER_PIXELS}    | choice    | Option to save time series of evap. rate [-] {Yes; No}
+er_ts_file          | {er_ts_file}        | string    | Filename for time series of evap. rate [mm/hr]
+#===============================================================================
+# About
+ModelName           | {ModelName}         | String    | Name of the model [-]
+ModelAuthor         | {ModelAuthor}       | String    | Name of the model author [-]
+HTML_HELP_FILE      | {HTML_HELP_FILE}    | String    | Url for html help file [-]

--- a/.bmi/evap_priestley_taylor/api.yaml
+++ b/.bmi/evap_priestley_taylor/api.yaml
@@ -1,0 +1,5 @@
+name: EvapPriestleyTaylor
+language: python
+
+package: topoflow.components.evap_priestley_taylor
+class: evap_component

--- a/.bmi/evap_priestley_taylor/info.yaml
+++ b/.bmi/evap_priestley_taylor/info.yaml
@@ -1,0 +1,4 @@
+url: https://github.com/peckhams/topoflow
+author: Scott Peckham
+email: scott.peckham@colorado.edu
+version: 3.1.0

--- a/.bmi/evap_priestley_taylor/parameters.yaml
+++ b/.bmi/evap_priestley_taylor/parameters.yaml
@@ -1,0 +1,23 @@
+%YAML 1.2
+---
+run_duration:
+  description: Simulation run time
+  value:
+    type: int
+    default: 1
+    units: d
+    range:
+      max: 1000000
+      min: 0
+site_prefix:
+  description: File prefix for the study site
+  value:
+    type: string
+    default: Treynor
+    units: '-'
+case_prefix:
+  description: File prefix for the model scenario
+  value:
+    type: string
+    default: Case5
+    units: '-'

--- a/.bmi/evap_read_file/Evap_Read_File.cfg.in
+++ b/.bmi/evap_read_file/Evap_Read_File.cfg.in
@@ -1,0 +1,26 @@
+#===============================================================================
+# Topoflow Config File for: evap_read_file
+#===============================================================================
+# Input
+comp_status         | Enabled             | choice    | Component status [-] {Enabled; Disabled}
+in_directory        | {in_directory}      | string    | Input directory [-]
+out_directory       | {out_directory}     | string    | Output directory [-]
+site_prefix         | {site_prefix}       | string    | File prefix for the study site [-]
+case_prefix         | {case_prefix}       | string    | File prefix for the model scenario [-]
+n_steps             | {n_steps}           | long      | Number of time steps [-]
+dt                  | {dt}                | float     | Timestep for evaporation rate [sec]
+ET_rate             | {ET_rate}           | string    | Grid sequence [mm/hr]
+#===============================================================================
+# Output
+save_grid_dt        | {save_grid_dt}      | float     | Time interval between saved grids [sec]
+SAVE_ER_GRIDS       | {SAVE_ER_GRIDS}     | choice    | Option to save grids of evap. rate [mm/hr] {Yes; No}
+er_gs_file          | {er_gs_file}        | string    | Filename for grid stack of evap. rate [mm/hr]
+save_pixels_dt      | {save_pixels_dt}    | float     | Time interval between time series values [sec]
+pixel_file          | {pixel_file}        | string    | Filename for monitored pixel file [-]
+SAVE_ER_PIXELS      | {SAVE_ER_PIXELS}    | choice    | Option to save time series of evap. rate [-] {Yes; No}
+er_ts_file          | {er_ts_file}        | string    | Filename for time series of evap. rate [mm/hr]
+#===============================================================================
+# About
+ModelName           | {ModelName}         | String    | Name of the model [-]
+ModelAuthor         | {ModelAuthor}       | String    | Name of the model author [-]
+HTML_HELP_FILE      | {HTML_HELP_FILE}    | String    | Url for html help file [-]

--- a/.bmi/evap_read_file/api.yaml
+++ b/.bmi/evap_read_file/api.yaml
@@ -1,0 +1,5 @@
+name: EvapReadFile
+language: python
+
+package: topoflow.components.evap_read_file
+class: evap_component

--- a/.bmi/evap_read_file/info.yaml
+++ b/.bmi/evap_read_file/info.yaml
@@ -1,0 +1,4 @@
+url: https://github.com/peckhams/topoflow
+author: Scott Peckham
+email: scott.peckham@colorado.edu
+version: 3.1.0

--- a/.bmi/evap_read_file/parameters.yaml
+++ b/.bmi/evap_read_file/parameters.yaml
@@ -1,0 +1,23 @@
+%YAML 1.2
+---
+run_duration:
+  description: Simulation run time
+  value:
+    type: int
+    default: 1
+    units: d
+    range:
+      max: 1000000
+      min: 0
+site_prefix:
+  description: File prefix for the study site
+  value:
+    type: string
+    default: Treynor
+    units: '-'
+case_prefix:
+  description: File prefix for the model scenario
+  value:
+    type: string
+    default: Case5
+    units: '-'

--- a/.bmi/infil_beven/Infil_Beven.cfg.in
+++ b/.bmi/infil_beven/Infil_Beven.cfg.in
@@ -1,0 +1,28 @@
+#===============================================================================
+# Topoflow Config File for: infil_beven
+#===============================================================================
+# Input
+comp_status         | Enabled             | choice    | Component status [-] {Enabled; Disabled}
+in_directory        | {in_directory}      | string    | Input directory [-]
+out_directory       | {out_directory}     | string    | Output directory [-]
+site_prefix         | {site_prefix}       | string    | File prefix for the study site [-]
+case_prefix         | {case_prefix}       | string    | File prefix for the model scenario [-]
+n_steps             | {n_steps}           | long      | Number of time steps [-]
+#===============================================================================
+# Output
+save_grid_dt        | {save_grid_dt}      | float     | Time interval between saved grids [sec]
+SAVE_V0_GRIDS       | {SAVE_V0_GRIDS}     | choice    | Option to save grids of infil. rate (at surf) [-] {Yes; No}
+v0_gs_file          | {v0_gs_file}        | string    | Filename for grid stack of v0 [m/s]
+SAVE_I_GRIDS        | {SAVE_I_GRIDS}      | choice    | Option to save grids of cumul. infil. depth [-] {Yes; No}
+I_gs_file           | {I_gs_file}         | string    | Filename for grid stack of i [m]
+save_pixels_dt      | {save_pixels_dt}    | float     | Time interval between time series values [sec]
+pixel_file          | {pixel_file}        | string    | Filename for monitored pixel file [-]
+SAVE_V0_PIXELS      | {SAVE_V0_PIXELS}    | choice    | Option to save time series of infil. rate (at surf) [-] {Yes; No}
+v0_ts_file          | {v0_ts_file}        | string    | Filename for time series of v0 [m/s]
+SAVE_I_PIXELS       | {SAVE_I_PIXELS}     | choice    | Option to save time series of cumul. infil. depth [-] {Yes; No}
+I_ts_file           | {I_ts_file}         | string    | Filename for time series of i [m]
+#===============================================================================
+# About
+ModelName           | {ModelName}         | String    | Name of the model [-]
+ModelAuthor         | {ModelAuthor}       | String    | Name of the model author [-]
+HTML_HELP_FILE      | {HTML_HELP_FILE}    | String    | Url for html help file [-]

--- a/.bmi/infil_beven/api.yaml
+++ b/.bmi/infil_beven/api.yaml
@@ -1,0 +1,5 @@
+name: InfilBeven
+language: python
+
+package: topoflow.components.infil_beven
+class: infil_component

--- a/.bmi/infil_beven/info.yaml
+++ b/.bmi/infil_beven/info.yaml
@@ -1,0 +1,4 @@
+url: https://github.com/peckhams/topoflow
+author: Scott Peckham
+email: scott.peckham@colorado.edu
+version: 3.1.0

--- a/.bmi/infil_beven/parameters.yaml
+++ b/.bmi/infil_beven/parameters.yaml
@@ -1,0 +1,23 @@
+%YAML 1.2
+---
+run_duration:
+  description: Simulation run time
+  value:
+    type: int
+    default: 1
+    units: d
+    range:
+      max: 1000000
+      min: 0
+site_prefix:
+  description: File prefix for the study site
+  value:
+    type: string
+    default: Treynor
+    units: '-'
+case_prefix:
+  description: File prefix for the model scenario
+  value:
+    type: string
+    default: Case5
+    units: '-'

--- a/.bmi/infil_green_ampt/Infil_Green_Ampt.cfg.in
+++ b/.bmi/infil_green_ampt/Infil_Green_Ampt.cfg.in
@@ -1,0 +1,43 @@
+#===============================================================================
+# Topoflow Config File for: infil_green_ampt
+#===============================================================================
+# Input
+comp_status         | Enabled             | choice    | Component status [-] {Enabled; Disabled}
+in_directory        | {in_directory}      | string    | Input directory [-]
+out_directory       | {out_directory}     | string    | Output directory [-]
+site_prefix         | {site_prefix}       | string    | File prefix for the study site [-]
+case_prefix         | {case_prefix}       | string    | File prefix for the model scenario [-]
+n_steps             | {n_steps}           | long      | Number of time steps [-]
+n_layers            | {n_layers}          | int       | Number of soil layers [-]
+dt                  | {dt}                | float     | Timestep for infiltration process [sec]
+#===============================================================================
+# Layer 1
+Ks_type_0           | {Ks_type_0}         | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+Ks_0                | {Ks_0}              | float     | Sat. hydraulic conductivity [m/s]
+Ki_type_0           | {Ki_type_0}         | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+Ki_0                | {Ki_0}              | float     | Init. hydraulic conductivity (< k_sat) [m/s]
+qs_type_0           | {qs_type_0}         | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+qs_0                | {qs_0}              | float     | Sat. soil water content [-]
+qi_type_0           | {qi_type_0}         | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+qi_0                | {qi_0}              | float     | Init. soil water content (< theta_sat) [-]
+G_type_0            | {G_type_0}          | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+G_0                 | {G_0}               | float     | Capillary length scale [m]
+soil_type_0         | {soil_type_0}       | choice    | Closest standard soil type [-] {sand; loamy_sand; sandy_loam; silty_loam; loam; sandy_clay_loam; silty_clay_loam; clay_loam; sandy_clay; silty_clay; clay}
+#===============================================================================
+# Output
+save_grid_dt        | {save_grid_dt}      | float     | Time interval between saved grids [sec]
+SAVE_V0_GRIDS       | {SAVE_V0_GRIDS}     | choice    | Option to save grids of infil. rate (at surf) [-] {Yes; No}
+v0_gs_file          | {v0_gs_file}        | string    | Filename for grid stack of v0 [m/s]
+SAVE_I_GRIDS        | {SAVE_I_GRIDS}      | choice    | Option to save grids of cumul. infil. depth [-] {Yes; No}
+I_gs_file           | {I_gs_file}         | string    | Filename for grid stack of i [m]
+save_pixels_dt      | {save_pixels_dt}    | float     | Time interval between time series values [sec]
+pixel_file          | {pixel_file}        | string    | Filename for monitored pixel file [-]
+SAVE_V0_PIXELS      | {SAVE_V0_PIXELS}    | choice    | Option to save time series of infil. rate (at surf) [-] {Yes; No}
+v0_ts_file          | {v0_ts_file}        | string    | Filename for time series of v0 [m/s]
+SAVE_I_PIXELS       | {SAVE_I_PIXELS}     | choice    | Option to save time series of cumul. infil. depth [-] {Yes; No}
+I_ts_file           | {I_ts_file}         | string    | Filename for time series of i [m]
+#===============================================================================
+# About
+ModelName           | {ModelName}         | String    | Name of the model [-]
+ModelAuthor         | {ModelAuthor}       | String    | Name of the model author [-]
+HTML_HELP_FILE      | {HTML_HELP_FILE}    | String    | Url for html help file [-]

--- a/.bmi/infil_green_ampt/api.yaml
+++ b/.bmi/infil_green_ampt/api.yaml
@@ -1,0 +1,5 @@
+name: InfilGreenAmpt
+language: python
+
+package: topoflow.components.infil_green_ampt
+class: infil_component

--- a/.bmi/infil_green_ampt/info.yaml
+++ b/.bmi/infil_green_ampt/info.yaml
@@ -1,0 +1,4 @@
+url: https://github.com/peckhams/topoflow
+author: Scott Peckham
+email: scott.peckham@colorado.edu
+version: 3.1.0

--- a/.bmi/infil_green_ampt/parameters.yaml
+++ b/.bmi/infil_green_ampt/parameters.yaml
@@ -1,0 +1,23 @@
+%YAML 1.2
+---
+run_duration:
+  description: Simulation run time
+  value:
+    type: int
+    default: 1
+    units: d
+    range:
+      max: 1000000
+      min: 0
+site_prefix:
+  description: File prefix for the study site
+  value:
+    type: string
+    default: Treynor
+    units: '-'
+case_prefix:
+  description: File prefix for the model scenario
+  value:
+    type: string
+    default: Case5
+    units: '-'

--- a/.bmi/infil_richards_1d/Infil_Richards_1D.cfg.in
+++ b/.bmi/infil_richards_1d/Infil_Richards_1D.cfg.in
@@ -1,0 +1,131 @@
+#===============================================================================
+# Topoflow Config File for: infil_richards_1d
+#===============================================================================
+# Input
+comp_status         | Enabled             | choice    | Component status [-] {Enabled; Disabled}
+in_directory        | {in_directory}      | string    | Input directory [-]
+out_directory       | {out_directory}     | string    | Output directory [-]
+site_prefix         | {site_prefix}       | string    | File prefix for the study site [-]
+case_prefix         | {case_prefix}       | string    | File prefix for the model scenario [-]
+n_steps             | {n_steps}           | long      | Number of time steps [-]
+n_layers            | {n_layers}          | int       | Number of soil layers [-]
+dt                  | {dt}                | float     | Timestep for infiltration process [sec]
+#===============================================================================
+# Layer 1
+Ks_type_0           | {Ks_type_0}         | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+Ks_val_0            | {Ks_val_0}          | float     | Sat. hydraulic conductivity [m/s]
+Ki_type_0           | {Ki_type_0}         | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+Ki_val_0            | {Ki_val_0}          | float     | Init. hydraulic conductivity (< k_sat) [m/s]
+qs_type_0           | {qs_type_0}         | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+qs_val_0            | {qs_val_0}          | float     | Sat. soil water content [-]
+qi_type_0           | {qi_type_0}         | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+qi_val_0            | {qi_val_0}          | float     | Init. soil water content (< theta_sat) [-]
+qr_type_0           | {qr_type_0}         | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+qr_val_0            | {qr_val_0}          | float     | Residual soil water content (< theta_init) [-]
+pB_type_0           | {pB_type_0}         | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+pB_val_0            | {pB_val_0}          | float     | Bubbling pressure head [m]
+pA_type_0           | {pA_type_0}         | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+pA_val_0            | {pA_val_0}          | float     | Pressure head offset parameter [m]
+lam_type_0          | {lam_type_0}        | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+lam_val_0           | {lam_val_0}         | float     | Pore-size distribution parameter [-]
+c_type_0            | {c_type_0}          | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+c_val_0             | {c_val_0}           | float     | Trans. brooks-corey curvature [-]
+dz_val_0            | {dz_val_0}          | float     | Vertical distance between nodes [m]
+nz_val_0            | {nz_val_0}          | int       | Number of vertical nodes in layer [-]
+soil_type_0         | {soil_type_0}       | choice    | Closest standard soil type [-] {sand; loamy_sand; sandy_loam; silty_loam; loam; sandy_clay_loam; silty_clay_loam; clay_loam; sandy_clay; silty_clay; clay}
+#===============================================================================
+# Layer 2
+Ks_type[1]          | {Ks_type[1]}        | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+Ks_val[1]           | {Ks_val[1]}         | float     | Sat. hydraulic conductivity [m/s]
+Ki_type[1]          | {Ki_type[1]}        | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+Ki_val[1]           | {Ki_val[1]}         | float     | Init. hydraulic conductivity (< k_sat) [m/s]
+qs_type[1]          | {qs_type[1]}        | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+qs_val[1]           | {qs_val[1]}         | float     | Sat. soil water content [-]
+qi_type[1]          | {qi_type[1]}        | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+qi_val[1]           | {qi_val[1]}         | float     | Init. soil water content (< theta_sat) [-]
+qr_type[1]          | {qr_type[1]}        | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+qr_val[1]           | {qr_val[1]}         | float     | Residual soil water content (< theta_init) [-]
+pB_type[1]          | {pB_type[1]}        | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+pB_val[1]           | {pB_val[1]}         | float     | Bubbling pressure head [m]
+pA_type[1]          | {pA_type[1]}        | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+pA_val[1]           | {pA_val[1]}         | float     | Pressure head offset parameter [m]
+lam_type[1]         | {lam_type[1]}       | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+lam_val[1]          | {lam_val[1]}        | float     | Pore-size distribution parameter [-]
+c_type[1]           | {c_type[1]}         | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+c_val[1]            | {c_val[1]}          | float     | Trans. brooks-corey curvature [-]
+dz_val[1]           | {dz_val[1]}         | float     | Vertical distance between nodes [m]
+nz_val[1]           | {nz_val[1]}         | int       | Number of vertical nodes in layer [-]
+soil_type[1]        | {soil_type[1]}      | choice    | Closest standard soil type [-] {sand; loamy_sand; sandy_loam; silty_loam; loam; sandy_clay_loam; silty_clay_loam; clay_loam; sandy_clay; silty_clay; clay}
+#===============================================================================
+# Layer 3
+Ks_type[2]          | {Ks_type[2]}        | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+Ks_val[2]           | {Ks_val[2]}         | float     | Sat. hydraulic conductivity [m/s]
+Ki_type[2]          | {Ki_type[2]}        | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+Ki_val[2]           | {Ki_val[2]}         | float     | Init. hydraulic conductivity (< k_sat) [m/s]
+qs_type[2]          | {qs_type[2]}        | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+qs_val[2]           | {qs_val[2]}         | float     | Sat. soil water content [-]
+qi_type[2]          | {qi_type[2]}        | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+qi_val[2]           | {qi_val[2]}         | float     | Init. soil water content (< theta_sat) [-]
+qr_type[2]          | {qr_type[2]}        | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+qr_val[2]           | {qr_val[2]}         | float     | Residual soil water content (< theta_init) [-]
+pB_type[2]          | {pB_type[2]}        | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+pB_val[2]           | {pB_val[2]}         | float     | Bubbling pressure head [m]
+pA_type[2]          | {pA_type[2]}        | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+pA_val[2]           | {pA_val[2]}         | float     | Pressure head offset parameter [m]
+lam_type[2]         | {lam_type[2]}       | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+lam_val[2]          | {lam_val[2]}        | float     | Pore-size distribution parameter [-]
+c_type[2]           | {c_type[2]}         | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+c_val[2]            | {c_val[2]}          | float     | Trans. brooks-corey curvature [-]
+dz_val[2]           | {dz_val[2]}         | float     | Vertical distance between nodes [m]
+nz_val[2]           | {nz_val[2]}         | int       | Number of vertical nodes in layer [-]
+soil_type[2]        | {soil_type[2]}      | choice    | Closest standard soil type [-] {sand; loamy_sand; sandy_loam; silty_loam; loam; sandy_clay_loam; silty_clay_loam; clay_loam; sandy_clay; silty_clay; clay}
+#===============================================================================
+# Output 1
+save_grid_dt        | {save_grid_dt}      | float     | Time interval between saved grids [sec]
+SAVE_V0_GRIDS       | {SAVE_V0_GRIDS}     | choice    | Option to save grids of infil. rate (at surf) [-] {Yes; No}
+v0_gs_file          | {v0_gs_file}        | string    | Filename for grid stack of v0 [m/s]
+SAVE_I_GRIDS        | {SAVE_I_GRIDS}      | choice    | Option to save grids of cumul. infil. depth [-] {Yes; No}
+I_gs_file           | {I_gs_file}         | string    | Filename for grid stack of i [m]
+SAVE_Q0_GRIDS       | {SAVE_Q0_GRIDS}     | choice    | Option to save grids of soil water content (at surf) [-] {Yes; No}
+q0_gs_file          | {q0_gs_file}        | string    | Filename for grid stack of q0 [-]
+SAVE_ZW_GRIDS       | {SAVE_ZW_GRIDS}     | choice    | Option to save grids of depth to wetting front [-] {Yes; No}
+Zw_gs_file          | {Zw_gs_file}        | string    | Filename for grid stack of zw [m]
+#===============================================================================
+# Output 2
+save_pixels_dt      | {save_pixels_dt}    | float     | Time interval between time series values [sec]
+pixel_file          | {pixel_file}        | string    | Filename for monitored pixel file [-]
+SAVE_V0_PIXELS      | {SAVE_V0_PIXELS}    | choice    | Option to save time series of infil. rate (at surf) [-] {Yes; No}
+v0_ts_file          | {v0_ts_file}        | string    | Filename for time series of v0 [m/s]
+SAVE_I_PIXELS       | {SAVE_I_PIXELS}     | choice    | Option to save time series of cumul. infil. depth [-] {Yes; No}
+I_ts_file           | {I_ts_file}         | string    | Filename for time series of i [m]
+SAVE_Q0_PIXELS      | {SAVE_Q0_PIXELS}    | choice    | Option to save time series of soil water content (at surf) [-] {Yes; No}
+q0_ts_file          | {q0_ts_file}        | string    | Filename for time series of q0 [-]
+SAVE_ZW_PIXELS      | {SAVE_ZW_PIXELS}    | choice    | Option to save time series of depth to wetting front [-] {Yes; No}
+Zw_ts_file          | {Zw_ts_file}        | string    | Filename for time series of zw [m]
+#===============================================================================
+# Output 3
+save_profile_dt     | {save_profile_dt}   | float     | Time interval between saved 1d profiles [sec]
+SAVE_Q_PROFILES     | {SAVE_Q_PROFILES}   | choice    | Option to save 1d profile of soil water content [-] {Yes; No}
+q_ps_file           | {q_ps_file}         | string    | Filename for 1d profile of theta [-]
+SAVE_P_PROFILES     | {SAVE_P_PROFILES}   | choice    | Option to save 1d profile of pressure head [-] {Yes; No}
+p_ps_file           | {p_ps_file}         | string    | Filename for 1d profile of psi [m]
+SAVE_K_PROFILES     | {SAVE_K_PROFILES}   | choice    | Option to save 1d profile of hydr. conductivity [-] {Yes; No}
+K_ps_file           | {K_ps_file}         | string    | Filename for 1d profile of k [m/s]
+SAVE_V_PROFILES     | {SAVE_V_PROFILES}   | choice    | Option to save 1d profile of vert. flow rate [-] {Yes; No}
+v_ps_file           | {v_ps_file}         | string    | Filename for 1d profile of v [m/s]
+#===============================================================================
+# Output 4
+save_cube_dt        | {save_cube_dt}      | float     | Time interval between saved 3d cubes [sec]
+SAVE_Q_CUBES        | {SAVE_Q_CUBES}      | choice    | Option to save 3d cubes of soil water content [-] {Yes; No}
+q_cs_file           | {q_cs_file}         | string    | Filename for 3d cubes of theta [-]
+SAVE_P_CUBES        | {SAVE_P_CUBES}      | choice    | Option to save 3d cubes of pressure head [-] {Yes; No}
+p_cs_file           | {p_cs_file}         | string    | Filename for 3d cubes of psi [m]
+SAVE_K_CUBES        | {SAVE_K_CUBES}      | choice    | Option to save 3d cubes of hydr. conductivity [-] {Yes; No}
+K_cs_file           | {K_cs_file}         | string    | Filename for 3d cubes of k [m/s]
+SAVE_V_CUBES        | {SAVE_V_CUBES}      | choice    | Option to save 3d cubes of vert. flow rate [-] {Yes; No}
+v_cs_file           | {v_cs_file}         | string    | Filename for 3d cubes of v [m/s]
+#===============================================================================
+# About
+ModelName           | {ModelName}         | String    | Name of the model [-]
+ModelAuthor         | {ModelAuthor}       | String    | Name of the model author [-]
+HTML_HELP_FILE      | {HTML_HELP_FILE}    | String    | Url for html help file [-]

--- a/.bmi/infil_richards_1d/api.yaml
+++ b/.bmi/infil_richards_1d/api.yaml
@@ -1,0 +1,5 @@
+name: InfilRichards1D
+language: python
+
+package: topoflow.components.infil_richards_1D
+class: infil_component

--- a/.bmi/infil_richards_1d/info.yaml
+++ b/.bmi/infil_richards_1d/info.yaml
@@ -1,0 +1,4 @@
+url: https://github.com/peckhams/topoflow
+author: Scott Peckham
+email: scott.peckham@colorado.edu
+version: 3.1.0

--- a/.bmi/infil_richards_1d/parameters.yaml
+++ b/.bmi/infil_richards_1d/parameters.yaml
@@ -1,0 +1,23 @@
+%YAML 1.2
+---
+run_duration:
+  description: Simulation run time
+  value:
+    type: int
+    default: 1
+    units: d
+    range:
+      max: 1000000
+      min: 0
+site_prefix:
+  description: File prefix for the study site
+  value:
+    type: string
+    default: Treynor
+    units: '-'
+case_prefix:
+  description: File prefix for the model scenario
+  value:
+    type: string
+    default: Case5
+    units: '-'

--- a/.bmi/infil_smith_parlange/Infil_Smith_Parlange.cfg.in
+++ b/.bmi/infil_smith_parlange/Infil_Smith_Parlange.cfg.in
@@ -1,0 +1,45 @@
+#===============================================================================
+# Topoflow Config File for: infil_smith_parlange
+#===============================================================================
+# Input
+comp_status         | Enabled             | choice    | Component status [-] {Enabled; Disabled}
+in_directory        | {in_directory}      | string    | Input directory [-]
+out_directory       | {out_directory}     | string    | Output directory [-]
+site_prefix         | {site_prefix}       | string    | File prefix for the study site [-]
+case_prefix         | {case_prefix}       | string    | File prefix for the model scenario [-]
+n_steps             | {n_steps}           | long      | Number of time steps [-]
+n_layers            | {n_layers}          | int       | Number of soil layers [-]
+dt                  | {dt}                | float     | Timestep for infiltration process [sec]
+#===============================================================================
+# Layer 1
+Ks_type_0           | {Ks_type_0}         | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+Ks_0                | {Ks_0}              | float     | Sat. hydraulic conductivity [m/s]
+Ki_type_0           | {Ki_type_0}         | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+Ki_0                | {Ki_0}              | float     | Init. hydraulic conductivity (< k_sat) [m/s]
+qs_type_0           | {qs_type_0}         | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+qs_0                | {qs_0}              | float     | Sat. soil water content [-]
+qi_type_0           | {qi_type_0}         | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+qi_0                | {qi_0}              | float     | Init. soil water content (< theta_sat) [-]
+G_type_0            | {G_type_0}          | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+G_0                 | {G_0}               | float     | Capillary length scale [m]
+gam_type_0          | {gam_type_0}        | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+gam_0               | {gam_0}             | float     | Smith-parlange parameter [-]
+soil_type_0         | {soil_type_0}       | choice    | Closest standard soil type [-] {sand; loamy_sand; sandy_loam; silty_loam; loam; sandy_clay_loam; silty_clay_loam; clay_loam; sandy_clay; silty_clay; clay}
+#===============================================================================
+# Output
+save_grid_dt        | {save_grid_dt}      | float     | Time interval between saved grids [sec]
+SAVE_V0_GRIDS       | {SAVE_V0_GRIDS}     | choice    | Option to save grids of infil. rate (at surf) [-] {Yes; No}
+v0_gs_file          | {v0_gs_file}        | string    | Filename for grid stack of v0 [m/s]
+SAVE_I_GRIDS        | {SAVE_I_GRIDS}      | choice    | Option to save grids of cumul. infil. depth [-] {Yes; No}
+I_gs_file           | {I_gs_file}         | string    | Filename for grid stack of i [m]
+save_pixels_dt      | {save_pixels_dt}    | float     | Time interval between time series values [sec]
+pixel_file          | {pixel_file}        | string    | Filename for monitored pixel file [-]
+SAVE_V0_PIXELS      | {SAVE_V0_PIXELS}    | choice    | Option to save time series of infil. rate (at surf) [-] {Yes; No}
+v0_ts_file          | {v0_ts_file}        | string    | Filename for time series of v0 [m/s]
+SAVE_I_PIXELS       | {SAVE_I_PIXELS}     | choice    | Option to save time series of cumul. infil. depth [-] {Yes; No}
+I_ts_file           | {I_ts_file}         | string    | Filename for time series of i [m]
+#===============================================================================
+# About
+ModelName           | {ModelName}         | String    | Name of the model [-]
+ModelAuthor         | {ModelAuthor}       | String    | Name of the model author [-]
+HTML_HELP_FILE      | {HTML_HELP_FILE}    | String    | Url for html help file [-]

--- a/.bmi/infil_smith_parlange/api.yaml
+++ b/.bmi/infil_smith_parlange/api.yaml
@@ -1,0 +1,5 @@
+name: InfilSmithParlange
+language: python
+
+package: topoflow.components.infil_smith_parlange
+class: infil_component

--- a/.bmi/infil_smith_parlange/info.yaml
+++ b/.bmi/infil_smith_parlange/info.yaml
@@ -1,0 +1,4 @@
+url: https://github.com/peckhams/topoflow
+author: Scott Peckham
+email: scott.peckham@colorado.edu
+version: 3.1.0

--- a/.bmi/infil_smith_parlange/parameters.yaml
+++ b/.bmi/infil_smith_parlange/parameters.yaml
@@ -1,0 +1,23 @@
+%YAML 1.2
+---
+run_duration:
+  description: Simulation run time
+  value:
+    type: int
+    default: 1
+    units: d
+    range:
+      max: 1000000
+      min: 0
+site_prefix:
+  description: File prefix for the study site
+  value:
+    type: string
+    default: Treynor
+    units: '-'
+case_prefix:
+  description: File prefix for the model scenario
+  value:
+    type: string
+    default: Case5
+    units: '-'

--- a/.bmi/meteorology/Meteorology.cfg.in
+++ b/.bmi/meteorology/Meteorology.cfg.in
@@ -1,0 +1,86 @@
+#===============================================================================
+# Topoflow Config File for: meteorology
+#===============================================================================
+# Input 1
+comp_status         | Enabled             | choice    | Component status [-] {Enabled; Disabled}
+in_directory        | {in_directory}      | string    | Input directory [-]
+out_directory       | {out_directory}     | string    | Output directory [-]
+site_prefix         | {site_prefix}       | string    | File prefix for the study site [-]
+case_prefix         | {case_prefix}       | string    | File prefix for the model scenario [-]
+n_steps             | {n_steps}           | long      | Number of time steps [-]
+dt                  | {dt}                | float     | Meteorology time step [sec]
+rho_H2O_type        | {rho_H2O_type}      | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+rho_H2O             | {rho_H2O}           | float     | Density of water [kg/m^3]
+Cp_air_type         | {Cp_air_type}       | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+Cp_air              | {Cp_air}            | float     | Heat capacity of air [J/kg/K]
+rho_air_type        | {rho_air_type}      | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+rho_air             | {rho_air}           | float     | Density of air [kg/m^3]
+P_type              | {P_type}            | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+P                   | {P}                 | string    | Precipitation rate [mm/hr]
+PRECIP_ONLY         | {PRECIP_ONLY}       | choice    | Toggle to turn off all variable updates except precip. [-] {Yes; No}
+#===============================================================================
+# Input 2
+T_air_type          | {T_air_type}        | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+T_air               | {T_air}             | float     | Temperature of air [degC]
+T_surf_type         | {T_surf_type}       | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+T_surf              | {T_surf}            | float     | Temperature of surface [degC]
+RH_type             | {RH_type}           | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+RH                  | {RH}                | float     | Relative humidity [-]
+p0_type             | {p0_type}           | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+p0                  | {p0}                | float     | Atmospheric pressure [mbar]
+uz_type             | {uz_type}           | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+uz                  | {uz}                | float     | Wind velocity at height z [m/s]
+z_type              | {z_type}            | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+z                   | {z}                 | float     | Wind reference height [m]
+z0_air_type         | {z0_air_type}       | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+z0_air              | {z0_air}            | float     | Surface roughness length scale for wind [m]
+#===============================================================================
+# Input 3
+albedo_type         | {albedo_type}       | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+albedo              | {albedo}            | float     | Surface albedo in [unitless]
+em_surf_type        | {em_surf_type}      | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+em_surf             | {em_surf}           | float     | Surface emissivity in [unitless]
+dust_atten_type     | {dust_atten_type}   | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+dust_atten          | {dust_atten}        | float     | Dust attenuation factor in [unitless]
+cloud_factor_type   | {cloud_factor_type} | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+cloud_factor        | {cloud_factor}      | float     | Cloudiness factor, c, in [unitless]
+canopy_factor_type  | {canopy_factor_type}| choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+canopy_factor       | {canopy_factor}     | float     | Canopy coverage factor, f, in [unitless]
+slope_grid_file     | {slope_grid_file}   | string    | Flat binary, row-major file with grid of 4-byte slopes [-]
+aspect_grid_file    | {aspect_grid_file}  | string    | Flat binary, row-major file with grid of 4-byte aspects [-]
+GMT_offset          | {GMT_offset}        | choice    | Time zone offset from gmt [-] {-12; -11; -10; -9; -8; -7; -6; -5; -4; -3; -2; -1; 0; 1; 2; 3; 4; 5; 6; 7; 8; 9; 10; 11; 12}
+start_month         | {start_month}       | choice    | Start month [-] {January; February; March; April; May; June; July; August; September; October; November; December}
+start_day           | {start_day}         | int       | Start day [-]
+start_hour          | {start_hour}        | float     | Start hour [-]
+#===============================================================================
+# Output 1
+save_grid_dt        | {save_grid_dt}      | float     | Time interval between saved grids [sec]
+SAVE_EA_GRIDS       | {SAVE_EA_GRIDS}     | choice    | Option to save grids of vapor pressure (in air) [-] {Yes; No}
+ea_gs_file          | {ea_gs_file}        | string    | Filename for grid stack of vapor pressure (air) [mbar]
+SAVE_ES_GRIDS       | {SAVE_ES_GRIDS}     | choice    | Option to save grids of vapor pressure (at surf) [-] {Yes; No}
+es_gs_file          | {es_gs_file}        | string    | Filename for grid stack of vapor pressure (surf) [mbar]
+SAVE_QSW_GRIDS      | {SAVE_QSW_GRIDS}    | choice    | Option to save grids of net shortwave radiation [-] {Yes; No}
+Qsw_gs_file         | {Qsw_gs_file}       | string    | Filename for grid stack of net shortwave radiation [W/m^2]
+SAVE_QLW_GRIDS      | {SAVE_QLW_GRIDS}    | choice    | Option to save grids of net longwave radiation [-] {Yes; No}
+Qlw_gs_file         | {Qlw_gs_file}       | string    | Filename for grid stack of net longwave radiation [W/m^2]
+SAVE_EMA_GRIDS      | {SAVE_EMA_GRIDS}    | choice    | Option to save grids of air emissivity [-] {Yes; No}
+ema_gs_file         | {ema_gs_file}       | string    | Filename for grid stack of air emissivity in [unitless]
+#===============================================================================
+# Output 2
+save_pixels_dt      | {save_pixels_dt}    | float     | Time interval between time series values [sec]
+pixel_file          | {pixel_file}        | string    | Filename for monitored pixel file [-]
+SAVE_EA_PIXELS      | {SAVE_EA_PIXELS}    | choice    | Option to save time series of sat. vapor press. (in air) [-] {Yes; No}
+ea_ts_file          | {ea_ts_file}        | string    | Filename for time series of sat. vapor press. (in air) [mbar]
+SAVE_ES_PIXELS      | {SAVE_ES_PIXELS}    | choice    | Option to save time series of sat. vapor press. (at surf) [-] {Yes; No}
+es_ts_file          | {es_ts_file}        | string    | Filename for time series of sat. vapor press. (at surf) [mbar]
+SAVE_QSW_PIXELS     | {SAVE_QSW_PIXELS}   | choice    | Option to save time series of net shortwave radiation [-] {Yes; No}
+Qsw_ts_file         | {Qsw_ts_file}       | string    | Filename for time series of net shortwave radiation [W/m^2]
+SAVE_QLW_PIXELS     | {SAVE_QLW_PIXELS}   | choice    | Option to save time series of net longwave radiation [-] {Yes; No}
+Qlw_ts_file         | {Qlw_ts_file}       | string    | Filename for time series of net longwave radiation [W/m^2]
+SAVE_EMA_PIXELS     | {SAVE_EMA_PIXELS}   | choice    | Option to save time series of air emissivity [-] {Yes; No}
+ema_ts_file         | {ema_ts_file}       | string    | Filename for time series of air emissivity in [unitless]
+#===============================================================================
+# About
+ModelName           | {ModelName}         | String    | Name of the model [-]
+ModelAuthor         | {ModelAuthor}       | String    | Name of the model author [-]
+HTML_HELP_FILE      | {HTML_HELP_FILE}    | String    | Url for html help file [-]

--- a/.bmi/meteorology/api.yaml
+++ b/.bmi/meteorology/api.yaml
@@ -1,0 +1,5 @@
+name: Meteorology
+language: python
+
+package: topoflow.components.met_base
+class: met_component

--- a/.bmi/meteorology/info.yaml
+++ b/.bmi/meteorology/info.yaml
@@ -1,0 +1,4 @@
+url: https://github.com/peckhams/topoflow
+author: Scott Peckham
+email: scott.peckham@colorado.edu
+version: 3.1.0

--- a/.bmi/meteorology/parameters.yaml
+++ b/.bmi/meteorology/parameters.yaml
@@ -1,0 +1,23 @@
+%YAML 1.2
+---
+run_duration:
+  description: Simulation run time
+  value:
+    type: int
+    default: 1
+    units: d
+    range:
+      max: 1000000
+      min: 0
+site_prefix:
+  description: File prefix for the study site
+  value:
+    type: string
+    default: Treynor
+    units: '-'
+case_prefix:
+  description: File prefix for the model scenario
+  value:
+    type: string
+    default: Case5
+    units: '-'

--- a/.bmi/satzone_darcy_layers/Satzone_Darcy_Layers.cfg.in
+++ b/.bmi/satzone_darcy_layers/Satzone_Darcy_Layers.cfg.in
@@ -1,0 +1,90 @@
+#===============================================================================
+# Topoflow Config File for: satzone_darcy_layers
+#===============================================================================
+# Input
+comp_status         | Enabled             | choice    | Component status [-] {Enabled; Disabled}
+in_directory        | {in_directory}      | string    | Input directory [-]
+out_directory       | {out_directory}     | string    | Output directory [-]
+site_prefix         | {site_prefix}       | string    | File prefix for the study site [-]
+case_prefix         | {case_prefix}       | string    | File prefix for the model scenario [-]
+n_steps             | {n_steps}           | long      | Number of time steps [-]
+n_layers            | {n_layers}          | int       | Number of soil layers [-]
+dt                  | {dt}                | float     | Timestep for subsurface flow [sec]
+elev_type           | {elev_type}         | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+elev                | {elev}              | string    | Land surface elevation [m]
+h0_table_type       | {h0_table_type}     | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+h0_table            | {h0_table}          | float     | Initial water table height [m]
+d_freeze_type       | {d_freeze_type}     | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+d_freeze            | {d_freeze}          | float     | Freeze depth below surface [m]
+d_thaw_type         | {d_thaw_type}       | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+d_thaw              | {d_thaw}            | float     | Thaw depth below surface [m]
+#===============================================================================
+# Layer 1
+Ks_type_0           | {Ks_type_0}         | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+Ks_0                | {Ks_0}              | float     | Sat. hydraulic conductivity [m/s]
+qs_type_0           | {qs_type_0}         | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+qs_0                | {qs_0}              | float     | Sat. soil water content [-]
+th_type_0           | {th_type_0}         | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+th_0                | {th_0}              | float     | Soil layer thickness [m]
+#===============================================================================
+# Layer 2
+Ks_type_1           | {Ks_type_1}         | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+Ks_1                | {Ks_1}              | float     | Sat. hydraulic conductivity [m/s]
+qs_type_1           | {qs_type_1}         | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+qs_1                | {qs_1}              | float     | Sat. soil water content [-]
+th_type_1           | {th_type_1}         | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+th_1                | {th_1}              | float     | Soil layer thickness [m]
+#===============================================================================
+# Layer 3
+Ks_type_2           | {Ks_type_2}         | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+Ks_2                | {Ks_2}              | float     | Sat. hydraulic conductivity [m/s]
+qs_type_2           | {qs_type_2}         | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+qs_2                | {qs_2}              | float     | Sat. soil water content [-]
+th_type_2           | {th_type_2}         | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+th_2                | {th_2}              | float     | Soil layer thickness [m]
+#===============================================================================
+# Layer 4
+Ks_type_3           | {Ks_type_3}         | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+Ks_3                | {Ks_3}              | float     | Sat. hydraulic conductivity [m/s]
+qs_type_3           | {qs_type_3}         | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+qs_3                | {qs_3}              | float     | Sat. soil water content [-]
+th_type_3           | {th_type_3}         | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+th_3                | {th_3}              | float     | Soil layer thickness [m]
+#===============================================================================
+# Layer 5
+Ks_type_4           | {Ks_type_4}         | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+Ks_4                | {Ks_4}              | float     | Sat. hydraulic conductivity [m/s]
+qs_type_4           | {qs_type_4}         | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+qs_4                | {qs_4}              | float     | Sat. soil water content [-]
+th_type_4           | {th_type_4}         | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+th_4                | {th_4}              | float     | Soil layer thickness [m]
+#===============================================================================
+# Layer 6
+Ks_type_5           | {Ks_type_5}         | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+Ks_5                | {Ks_5}              | float     | Sat. hydraulic conductivity [m/s]
+qs_type_5           | {qs_type_5}         | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+qs_5                | {qs_5}              | float     | Sat. soil water content [-]
+th_type_5           | {th_type_5}         | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+th_5                | {th_5}              | float     | Soil layer thickness [m]
+#===============================================================================
+# Output
+save_grid_dt        | {save_grid_dt}      | float     | Time interval between saved grids [sec]
+SAVE_HT_GRIDS       | {SAVE_HT_GRIDS}     | choice    | Option to save grids of water table height [-] {Yes; No}
+ht_gs_file          | {ht_gs_file}        | string    | Filename for grid stack of water table height [m]
+SAVE_DF_GRIDS       | {SAVE_DF_GRIDS}     | choice    | Option to save grids of freeze depth [-] {Yes; No}
+df_gs_file          | {df_gs_file}        | string    | Filename for grid stack of freeze depth [m]
+SAVE_DT_GRIDS       | {SAVE_DT_GRIDS}     | choice    | Option to save grids of thaw depth [-] {Yes; No}
+dt_gs_file          | {dt_gs_file}        | string    | Filename for grid stack of thaw depth [m]
+save_pixels_dt      | {save_pixels_dt}    | float     | Time interval between time series values [sec]
+pixel_file          | {pixel_file}        | string    | Filename for monitored pixel file [-]
+SAVE_HT_PIXELS      | {SAVE_HT_PIXELS}    | choice    | Option to save time series of water table height [-] {Yes; No}
+ht_ts_file          | {ht_ts_file}        | string    | Filename for time series of water table height [m]
+SAVE_DF_PIXELS      | {SAVE_DF_PIXELS}    | choice    | Option to save time series of freeze depth [-] {Yes; No}
+df_ts_file          | {df_ts_file}        | string    | Filename for time series of freeze depth [m]
+SAVE_DT_PIXELS      | {SAVE_DT_PIXELS}    | choice    | Option to save time series of thaw depth [-] {Yes; No}
+dt_ts_file          | {dt_ts_file}        | string    | Filename for time series of thaw depth [m]
+#===============================================================================
+# About
+ModelName           | {ModelName}         | String    | Name of the model [-]
+ModelAuthor         | {ModelAuthor}       | String    | Name of the model author [-]
+HTML_HELP_FILE      | {HTML_HELP_FILE}    | String    | Url for html help file [-]

--- a/.bmi/satzone_darcy_layers/api.yaml
+++ b/.bmi/satzone_darcy_layers/api.yaml
@@ -1,0 +1,5 @@
+name: SatZoneDarcyLayers
+language: python
+
+package: topoflow.components.satzone_darcy_layers
+class: satzone_component

--- a/.bmi/satzone_darcy_layers/info.yaml
+++ b/.bmi/satzone_darcy_layers/info.yaml
@@ -1,0 +1,4 @@
+url: https://github.com/peckhams/topoflow
+author: Scott Peckham
+email: scott.peckham@colorado.edu
+version: 3.1.0

--- a/.bmi/satzone_darcy_layers/parameters.yaml
+++ b/.bmi/satzone_darcy_layers/parameters.yaml
@@ -1,0 +1,23 @@
+%YAML 1.2
+---
+run_duration:
+  description: Simulation run time
+  value:
+    type: int
+    default: 1
+    units: d
+    range:
+      max: 1000000
+      min: 0
+site_prefix:
+  description: File prefix for the study site
+  value:
+    type: string
+    default: Treynor
+    units: '-'
+case_prefix:
+  description: File prefix for the model scenario
+  value:
+    type: string
+    default: Case5
+    units: '-'

--- a/.bmi/snow_degree_day/Snow_Degree_Day.cfg.in
+++ b/.bmi/snow_degree_day/Snow_Degree_Day.cfg.in
@@ -1,0 +1,51 @@
+#===============================================================================
+# Topoflow Config File for: snow_degree_day
+#===============================================================================
+# Input
+comp_status         | Enabled             | choice    | Component status [-] {Enabled; Disabled}
+in_directory        | {in_directory}      | string    | Input directory [-]
+out_directory       | {out_directory}     | string    | Output directory [-]
+site_prefix         | {site_prefix}       | string    | File prefix for the study site [-]
+case_prefix         | {case_prefix}       | string    | File prefix for the model scenario [-]
+n_steps             | {n_steps}           | long      | Number of time steps [-]
+dt                  | {dt}                | float     | Timestep for snowmelt process [sec]
+Cp_snow_type        | {Cp_snow_type}      | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+Cp_snow             | {Cp_snow}           | float     | Heat capacity of snow [J/kg/K]
+rho_snow_type       | {rho_snow_type}     | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+rho_snow            | {rho_snow}          | float     | Density of snow [kg/m^3]
+c0_type             | {c0_type}           | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+c0                  | {c0}                | float     | Degree-day coefficient [mm/day/degC]
+T0_type             | {T0_type}           | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+T0                  | {T0}                | float     | Reference temperature [degC]
+h0_snow_type        | {h0_snow_type}      | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+h0_snow             | {h0_snow}           | float     | Depth of snow [m]
+h0_swe_type         | {h0_swe_type}       | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+h0_swe              | {h0_swe}            | float     | Depth of snow water equivalent (swe) [m]
+#===============================================================================
+# Output 1
+save_grid_dt        | {save_grid_dt}      | float     | Time interval between saved grids [sec]
+SAVE_MR_GRIDS       | {SAVE_MR_GRIDS}     | choice    | Option to save grids of snow meltrate [-] {Yes; No}
+mr_gs_file          | {mr_gs_file}        | string    | Filename for grid stack of snow meltrate [m/s]
+SAVE_HS_GRIDS       | {SAVE_HS_GRIDS}     | choice    | Option to save grids of snow depth [-] {Yes; No}
+hs_gs_file          | {hs_gs_file}        | string    | Filename for grid stack of snow depth [m]
+SAVE_SW_GRIDS       | {SAVE_SW_GRIDS}     | choice    | Option to save grids of snow water equivalent [-] {Yes; No}
+sw_gs_file          | {sw_gs_file}        | string    | Filename for grid stack of snow water equivalent [m]
+SAVE_CC_GRIDS       | {SAVE_CC_GRIDS}     | choice    | Option to save grids of cold content [-] {Yes; No}
+cc_gs_file          | {cc_gs_file}        | string    | Filename for grid stack of cold content [J/m^2]
+#===============================================================================
+# Output 2
+save_pixels_dt      | {save_pixels_dt}    | float     | Time interval between time series values [sec]
+pixel_file          | {pixel_file}        | string    | Filename for monitored pixel file [-]
+SAVE_MR_PIXELS      | {SAVE_MR_PIXELS}    | choice    | Option to save time series of snow meltrate [-] {Yes; No}
+mr_ts_file          | {mr_ts_file}        | string    | Filename for time series of [m/s]
+SAVE_HS_PIXELS      | {SAVE_HS_PIXELS}    | choice    | Option to save time series of snow depth [-] {Yes; No}
+hs_ts_file          | {hs_ts_file}        | string    | Filename for time series of snow depth [m]
+SAVE_SW_PIXELS      | {SAVE_SW_PIXELS}    | choice    | Option to save time series of snow water equivalent [-] {Yes; No}
+sw_ts_file          | {sw_ts_file}        | string    | Filename for time series of snow water equivalent [m]
+SAVE_CC_PIXELS      | {SAVE_CC_PIXELS}    | choice    | Option to save time series of cold content [-] {Yes; No}
+cc_ts_file          | {cc_ts_file}        | string    | Filename for time series of cold content [J/m^2]
+#===============================================================================
+# About
+ModelName           | {ModelName}         | String    | Name of the model [-]
+ModelAuthor         | {ModelAuthor}       | String    | Name of the model author [-]
+HTML_HELP_FILE      | {HTML_HELP_FILE}    | String    | Url for html help file [-]

--- a/.bmi/snow_degree_day/api.yaml
+++ b/.bmi/snow_degree_day/api.yaml
@@ -1,0 +1,5 @@
+name: SnowDegreeDay
+language: python
+
+package: topoflow.components.snow_degree_day
+class: snow_component

--- a/.bmi/snow_degree_day/info.yaml
+++ b/.bmi/snow_degree_day/info.yaml
@@ -1,0 +1,4 @@
+url: https://github.com/peckhams/topoflow
+author: Scott Peckham
+email: scott.peckham@colorado.edu
+version: 3.1.0

--- a/.bmi/snow_degree_day/parameters.yaml
+++ b/.bmi/snow_degree_day/parameters.yaml
@@ -1,0 +1,23 @@
+%YAML 1.2
+---
+run_duration:
+  description: Simulation run time
+  value:
+    type: int
+    default: 1
+    units: d
+    range:
+      max: 1000000
+      min: 0
+site_prefix:
+  description: File prefix for the study site
+  value:
+    type: string
+    default: Treynor
+    units: '-'
+case_prefix:
+  description: File prefix for the model scenario
+  value:
+    type: string
+    default: Case5
+    units: '-'

--- a/.bmi/snow_energy_balance/Snow_Energy_Balance.cfg.in
+++ b/.bmi/snow_energy_balance/Snow_Energy_Balance.cfg.in
@@ -1,0 +1,51 @@
+#===============================================================================
+# Topoflow Config File for: snow_energy_balance
+#===============================================================================
+# Input
+comp_status         | Enabled             | choice    | Component status [-] {Enabled; Disabled}
+in_directory        | {in_directory}      | string    | Input directory [-]
+out_directory       | {out_directory}     | string    | Output directory [-]
+site_prefix         | {site_prefix}       | string    | File prefix for the study site [-]
+case_prefix         | {case_prefix}       | string    | File prefix for the model scenario [-]
+n_steps             | {n_steps}           | long      | Number of time steps [-]
+dt                  | {dt}                | float     | Timestep for snowmelt process [sec]
+Cp_snow_type        | {Cp_snow_type}      | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+Cp_snow             | {Cp_snow}           | float     | Heat capacity of snow [J/kg/K]
+rho_snow_type       | {rho_snow_type}     | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+rho_snow            | {rho_snow}          | float     | Density of snow [kg/m^3]
+c0_type             | {c0_type}           | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+c0                  | {c0}                | float     | Degree-day coefficient [mm/day/degC]
+T0_type             | {T0_type}           | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+T0                  | {T0}                | float     | Reference temperature [degC]
+h0_snow_type        | {h0_snow_type}      | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+h0_snow             | {h0_snow}           | float     | Depth of snow [m]
+h0_swe_type         | {h0_swe_type}       | choice    | Allowed input types [-] {Scalar; Grid; Time_Series; Grid_Sequence}
+h0_swe              | {h0_swe}            | float     | Depth of snow water equivalent (swe) [m]
+#===============================================================================
+# Output 1
+save_grid_dt        | {save_grid_dt}      | float     | Time interval between saved grids [sec]
+SAVE_MR_GRIDS       | {SAVE_MR_GRIDS}     | choice    | Option to save grids of snow meltrate [-] {Yes; No}
+mr_gs_file          | {mr_gs_file}        | string    | Filename for grid stack of snow meltrate [m/s]
+SAVE_HS_GRIDS       | {SAVE_HS_GRIDS}     | choice    | Option to save grids of snow depth [-] {Yes; No}
+hs_gs_file          | {hs_gs_file}        | string    | Filename for grid stack of snow depth [m]
+SAVE_SW_GRIDS       | {SAVE_SW_GRIDS}     | choice    | Option to save grids of snow water equivalent [-] {Yes; No}
+sw_gs_file          | {sw_gs_file}        | string    | Filename for grid stack of snow water equivalent [m]
+SAVE_CC_GRIDS       | {SAVE_CC_GRIDS}     | choice    | Option to save grids of cold content [-] {Yes; No}
+cc_gs_file          | {cc_gs_file}        | string    | Filename for grid stack of cold content [J/m^2]
+#===============================================================================
+# Output 2
+save_pixels_dt      | {save_pixels_dt}    | float     | Time interval between time series values [sec]
+pixel_file          | {pixel_file}        | string    | Filename for monitored pixel file [-]
+SAVE_MR_PIXELS      | {SAVE_MR_PIXELS}    | choice    | Option to save time series of snow meltrate [-] {Yes; No}
+mr_ts_file          | {mr_ts_file}        | string    | Filename for time series of [m/s]
+SAVE_HS_PIXELS      | {SAVE_HS_PIXELS}    | choice    | Option to save time series of snow depth [-] {Yes; No}
+hs_ts_file          | {hs_ts_file}        | string    | Filename for time series of snow depth [m]
+SAVE_SW_PIXELS      | {SAVE_SW_PIXELS}    | choice    | Option to save time series of snow water equivalent [-] {Yes; No}
+sw_ts_file          | {sw_ts_file}        | string    | Filename for time series of snow water equivalent [m]
+SAVE_CC_PIXELS      | {SAVE_CC_PIXELS}    | choice    | Option to save time series of cold content [-] {Yes; No}
+cc_ts_file          | {cc_ts_file}        | string    | Filename for time series of cold content [J/m^2]
+#===============================================================================
+# About
+ModelName           | {ModelName}         | String    | Name of the model [-]
+ModelAuthor         | {ModelAuthor}       | String    | Name of the model author [-]
+HTML_HELP_FILE      | {HTML_HELP_FILE}    | String    | Url for html help file [-]

--- a/.bmi/snow_energy_balance/api.yaml
+++ b/.bmi/snow_energy_balance/api.yaml
@@ -1,0 +1,5 @@
+name: SnowEnergyBalance
+language: python
+
+package: topoflow.components.snow_energy_balance
+class: snow_component

--- a/.bmi/snow_energy_balance/info.yaml
+++ b/.bmi/snow_energy_balance/info.yaml
@@ -1,0 +1,4 @@
+url: https://github.com/peckhams/topoflow
+author: Scott Peckham
+email: scott.peckham@colorado.edu
+version: 3.1.0

--- a/.bmi/snow_energy_balance/parameters.yaml
+++ b/.bmi/snow_energy_balance/parameters.yaml
@@ -1,0 +1,23 @@
+%YAML 1.2
+---
+run_duration:
+  description: Simulation run time
+  value:
+    type: int
+    default: 1
+    units: d
+    range:
+      max: 1000000
+      min: 0
+site_prefix:
+  description: File prefix for the study site
+  value:
+    type: string
+    default: Treynor
+    units: '-'
+case_prefix:
+  description: File prefix for the model scenario
+  value:
+    type: string
+    default: Case5
+    units: '-'

--- a/.bmi/topoflow/Topoflow.cfg.in
+++ b/.bmi/topoflow/Topoflow.cfg.in
@@ -1,0 +1,18 @@
+#===============================================================================
+# Topoflow Config File for: topoflow
+#===============================================================================
+# Input Parameters
+comp_status         | Enabled             | choice    | Component status [-] {Enabled; Disabled}
+in_directory        | {in_directory}      | String    | Input directory [-]
+out_directory       | {out_directory}     | String    | Output directory [-]
+site_prefix         | {site_prefix}       | String    | File prefix for the study site [-]
+case_prefix         | {case_prefix}       | String    | File prefix for the model scenario [-]
+stop_method         | {stop_method}       | choice    | Stopping method [-] {Q_peak_fraction; Until_model_time; Until_n_steps}
+Qp_fraction         | {Qp_fraction}       | Float     | Value for q_peak_fraction method [-]
+T_stop_model        | {T_stop_model}      | Float     | Value for until_model_time method [minutes]
+n_steps             | {n_steps}           | Int       | Value for until_n_steps method [-]
+#===============================================================================
+# About
+ModelName           | {ModelName}         | String    | Name of the model [-]
+ModelAuthor         | {ModelAuthor}       | String    | Name of the model author [-]
+HTML_HELP_FILE      | {HTML_HELP_FILE}    | String    | Url for html help file [-]

--- a/.bmi/topoflow/api.yaml
+++ b/.bmi/topoflow/api.yaml
@@ -1,0 +1,5 @@
+name: TopoFlow
+language: python
+
+package: topoflow.components.topoflow_driver
+class: topoflow_driver

--- a/.bmi/topoflow/info.yaml
+++ b/.bmi/topoflow/info.yaml
@@ -1,0 +1,4 @@
+url: https://github.com/peckhams/topoflow
+author: Scott Peckham
+email: scott.peckham@colorado.edu
+version: 3.1.0

--- a/.bmi/topoflow/parameters.yaml
+++ b/.bmi/topoflow/parameters.yaml
@@ -1,0 +1,23 @@
+%YAML 1.2
+---
+run_duration:
+  description: Simulation run time
+  value:
+    type: int
+    default: 1
+    units: d
+    range:
+      max: 1000000
+      min: 0
+site_prefix:
+  description: File prefix for the study site
+  value:
+    type: string
+    default: Treynor
+    units: '-'
+case_prefix:
+  description: File prefix for the model scenario
+  value:
+    type: string
+    default: Case5
+    units: '-'

--- a/topoflow/components/channels_base.py
+++ b/topoflow/components/channels_base.py
@@ -509,6 +509,41 @@ class channels_component( BMI_base.BMI_component ):
         print 'CHANNELS calling read_input_files()...'
         self.read_input_files()
 
+        # Attempt to define default values for running channels
+        # components in standalone mode. (@mdpiper, 8/19/15)
+        try:
+            self.P_rain
+        except AttributeError:
+            self.P_rain = np.float64(0.0)
+        try:
+            self.SM
+        except AttributeError:
+            self.SM = np.float64(0.0)
+        try:
+            self.ET
+        except AttributeError:
+            self.ET = np.float64(0.0)
+        try:
+            self.GW
+        except AttributeError:
+            self.GW = np.float64(0.0)
+        try:
+            self.IN
+        except AttributeError:
+            self.IN = np.float64(0.0)
+        try:
+            self.MR
+        except AttributeError:
+            self.MR = np.float64(0.0)
+        try:
+            self.rho_H2O
+        except AttributeError:
+            self.rho_H2O = np.float64(1000.0)  # met_base.py:525
+        try:
+            self.S_free
+        except AttributeError:
+            self.S_free = np.zeros(self.slope.shape)  # DEM shape from rti file
+
         #-----------------------
         # Initialize variables
         #-----------------------

--- a/topoflow/components/channels_dynamic_wave.py
+++ b/topoflow/components/channels_dynamic_wave.py
@@ -151,6 +151,10 @@ class channels_component(channels_base.channels_component):
 ##        A2 = ds_chan * Pw                           #(wetted surf. area)
         Atrm = (u * Q) * ((np.float64(1) / Atop) - (np.float64(1) / A2))
         #---------------------------------------
+
+        # Local variable `dinv` is not defined. (@mdpiper, 8/19/15)
+        dinv = 1.0  # least harm?
+
         acc = (grav + Atrm - fric - Rtrm)          #(positive or negative)
         u2  = u + (self.dt * dinv * acc)           #(before next part)
         #----------------------------------

--- a/topoflow/components/evap_base.py
+++ b/topoflow/components/evap_base.py
@@ -152,6 +152,37 @@ class evap_component( BMI_base.BMI_component):
         self.open_input_files()
         self.read_input_files()
 
+        # Attempt to define default values for running evaporation
+        # components in standalone mode. (@mdpiper, 8/19/15)
+        try:
+            self.h_snow
+        except AttributeError:
+            self.h_snow = np.float64(0.0)
+        try:
+            self.Q_sum
+        except AttributeError:
+            self.Q_sum = np.float64(0.0)
+        try:
+            self.Qe
+        except AttributeError:
+            self.Qe = np.float64(0.0)
+        try:
+            self.Qn_SW
+        except AttributeError:
+            self.Qn_SW = np.float64(0.0)
+        try:
+            self.Qn_LW
+        except AttributeError:
+            self.Qn_LW = np.float64(0.0)
+        try:
+            self.T_air
+        except AttributeError:
+            self.T_air = np.float64(0.0)
+        try:
+            self.T_surf
+        except AttributeError:
+            self.T_surf = np.float64(0.0)
+
         #-----------------------
         # Initialize variables
         #-----------------------

--- a/topoflow/components/gc2d.py
+++ b/topoflow/components/gc2d.py
@@ -982,8 +982,8 @@ def get_timestep( H, Zi_ext, Zi , dHdt, Bxy,
             
     # something like standard deviation of 3x3 cell areas around each cell
     filt   = numpy.ones( (3,3) , dtype='Float64' ) / 9.
-    ZiMean = filter2d( filt , Zi_ext , 'valid' )
-    dHmax  = numpy.sqrt( filter2d( filt, (ZiMean - Zi)**2 ) )
+    ZiMean = filter2d(Zi_ext, filt, 'valid')
+    dHmax  = numpy.sqrt(filter2d((ZiMean - Zi)**2, filt))
             
     # only consider cells with ice thickness > 10 m
     isGlac = (H > 10.)

--- a/topoflow/components/infil_base.py
+++ b/topoflow/components/infil_base.py
@@ -196,6 +196,31 @@ class infil_component( BMI_base.BMI_component):
         self.open_input_files()
         self.read_input_files()
 
+        # Attempt to define default values for running infiltration
+        # components in standalone mode. The h_table and elev
+        # attributes in particular should be reviewed in light of the
+        # comment block beginning on line 589. (@mdpiper, 8/18/15)
+        try:
+            self.P_rain
+        except AttributeError:
+            self.P_rain = np.float64(0.0)
+        try:
+            self.SM
+        except AttributeError:
+            self.SM = np.float64(0.0)
+        try:
+            self.ET
+        except AttributeError:
+            self.ET = np.float64(0.0)
+        try:
+            self.h_table
+        except AttributeError:
+            self.h_table = np.float64(0.0)
+        try:
+            self.elev
+        except AttributeError:
+            self.elev = np.float64(0.0)
+
         #----------------------------------------------
         # Must come before initialize_computed_vars()
         # because it uses ALL_SCALARS.

--- a/topoflow/components/met_base.py
+++ b/topoflow/components/met_base.py
@@ -1134,7 +1134,7 @@ class met_component( BMI_base.BMI_component ):
         try:
             self.h_snow
         except AttributeError:
-            self.h_snow = 0.0
+            self.h_snow = np.float64(0.0)
         h_snow = self.h_snow  # (ref from new framework)
         
         #---------------------------------------------------

--- a/topoflow/components/met_base.py
+++ b/topoflow/components/met_base.py
@@ -1131,6 +1131,10 @@ class met_component( BMI_base.BMI_component ):
         #        kappa    = 0.408 = von Karman's constant [unitless]
         #        RI       = Richardson's number (see function)
         #----------------------------------------------------------------
+        try:
+            self.h_snow
+        except AttributeError:
+            self.h_snow = 0.0
         h_snow = self.h_snow  # (ref from new framework)
         
         #---------------------------------------------------

--- a/topoflow/components/satzone_base.py
+++ b/topoflow/components/satzone_base.py
@@ -325,16 +325,32 @@ class satzone_component( BMI_base.BMI_component ):
     #   update()
     #-------------------------------------------------------------------
 
+    def update_frac(self, time_frac):
+        """Update model by a fraction of a time step.
+
+        Parameters
+        ----------
+        time_frac : float
+            Fraction of a time step.
+        """
+        time_step = self.get_time_step()
+        self.dt = time_frac * time_step
+        self.update()
+        self.dt = time_step
+
     def update_until(self, then):
         """Advance model state until the given time.
 
         Parameters
         ----------
         then : float
-          A model time value.
+            Time to run model until.
         """
-        while self.get_current_time() < then:
+        n_steps = (then - self.get_current_time()) / self.get_time_step()
+
+        for _ in xrange(int(n_steps)):
             self.update()
+        self.update_frac(n_steps - int(n_steps))
 
     def finalize(self):
 

--- a/topoflow/components/satzone_base.py
+++ b/topoflow/components/satzone_base.py
@@ -928,7 +928,14 @@ class satzone_component( BMI_base.BMI_component ):
         # Initialize dzw with outflow term.
         # Doesn't involve neighbor pixels.
         #------------------------------------
-        Rg  = self.Rg   # (using new framework, 5/18/12)
+        # Rg  = self.Rg   # (using new framework, 5/18/12)
+
+        # Use default value of Rg from infil_base.py if running as
+        # standalone component. (@mdpiper, 8/17/15)
+        try:
+            Rg = self.Rg
+        except AttributeError:
+            Rg = self.Rg = 0.0
         
         dzw = self.dt * (Rg - self.Q_gw / self.da)    ### USE gp.dt vs. main_dt !! ###
         

--- a/topoflow/components/satzone_base.py
+++ b/topoflow/components/satzone_base.py
@@ -324,34 +324,6 @@ class satzone_component( BMI_base.BMI_component ):
         
     #   update()
     #-------------------------------------------------------------------
-
-    def update_frac(self, time_frac):
-        """Update model by a fraction of a time step.
-
-        Parameters
-        ----------
-        time_frac : float
-            Fraction of a time step.
-        """
-        time_step = self.get_time_step()
-        self.dt = time_frac * time_step
-        self.update()
-        self.dt = time_step
-
-    def update_until(self, then):
-        """Advance model state until the given time.
-
-        Parameters
-        ----------
-        then : float
-            Time to run model until.
-        """
-        n_steps = (then - self.get_current_time()) / self.get_time_step()
-
-        for _ in xrange(int(n_steps)):
-            self.update()
-        self.update_frac(n_steps - int(n_steps))
-
     def finalize(self):
 
         self.status = 'finalizing'  # (OpenMI 2.0 convention)

--- a/topoflow/components/satzone_base.py
+++ b/topoflow/components/satzone_base.py
@@ -947,7 +947,7 @@ class satzone_component( BMI_base.BMI_component ):
         try:
             Rg = self.Rg
         except AttributeError:
-            Rg = self.Rg = 0.0
+            Rg = self.Rg = np.float64(0.0)
         
         dzw = self.dt * (Rg - self.Q_gw / self.da)    ### USE gp.dt vs. main_dt !! ###
         

--- a/topoflow/components/satzone_base.py
+++ b/topoflow/components/satzone_base.py
@@ -324,6 +324,18 @@ class satzone_component( BMI_base.BMI_component ):
         
     #   update()
     #-------------------------------------------------------------------
+
+    def update_until(self, then):
+        """Advance model state until the given time.
+
+        Parameters
+        ----------
+        then : float
+          A model time value.
+        """
+        while self.get_current_time() < then:
+            self.update()
+
     def finalize(self):
 
         self.status = 'finalizing'  # (OpenMI 2.0 convention)

--- a/topoflow/components/snow_base.py
+++ b/topoflow/components/snow_base.py
@@ -161,20 +161,37 @@ class snow_component( BMI_base.BMI_component ):
         self.open_input_files()
         self.read_input_files()
 
-        # Supply default values when running as standalone component.
-        # The T_air choice should be reviewed. (@mdpiper, 8/18/15)
+        # Supply default values when running as a standalone component.
+        # The T_air, T_surf, and Q_sum choices should be reviewed. 
+        # (@mdpiper, 8/18/15)
         try:
             self.P_snow
         except AttributeError:
-            self.P_snow = 0  # from met_base.py
+            self.P_snow = 0.0  # from met_base.py, no precip
         try:
             self.rho_H2O
         except AttributeError:
-            self.rho_H2O = 1000  # also from met_base.py
+            self.rho_H2O = 1000.0  # met_base.py:525
         try:
             self.T_air
         except AttributeError:
-            self.T_air = 0  # iffy: T_air <= 0 needed for P_snow
+            self.T_air = 0.0  # iffy: T_air <= 0 needed for P_snow
+        try:
+            self.rho_air
+        except AttributeError:
+            self.rho_air = 1.2614  # met_base.py:526
+        try:
+            self.Cp_air
+        except AttributeError:
+            self.Cp_air = 1005.7  # met_base.py:527
+        try:
+            self.T_surf
+        except AttributeError:
+            self.T_surf = self.T0  # see snow_energy_balance.py:358
+        try:
+            self.Q_sum
+        except AttributeError:
+            self.Q_sum = 0.0  # iffy: from init in met_base.py
 
         #---------------------------
         # Initialize computed vars

--- a/topoflow/components/snow_base.py
+++ b/topoflow/components/snow_base.py
@@ -161,6 +161,21 @@ class snow_component( BMI_base.BMI_component ):
         self.open_input_files()
         self.read_input_files()
 
+        # Supply default values when running as standalone component.
+        # The T_air choice should be reviewed. (@mdpiper, 8/18/15)
+        try:
+            self.P_snow
+        except AttributeError:
+            self.P_snow = 0  # from met_base.py
+        try:
+            self.rho_H2O
+        except AttributeError:
+            self.rho_H2O = 1000  # also from met_base.py
+        try:
+            self.T_air
+        except AttributeError:
+            self.T_air = 0  # iffy: T_air <= 0 needed for P_snow
+
         #---------------------------
         # Initialize computed vars
         #---------------------------

--- a/topoflow/components/snow_base.py
+++ b/topoflow/components/snow_base.py
@@ -167,23 +167,23 @@ class snow_component( BMI_base.BMI_component ):
         try:
             self.P_snow
         except AttributeError:
-            self.P_snow = 0.0  # from met_base.py, no precip
+            self.P_snow = np.float64(0.0)  # from met_base.py, no precip
         try:
             self.rho_H2O
         except AttributeError:
-            self.rho_H2O = 1000.0  # met_base.py:525
+            self.rho_H2O = np.float64(1000.0)  # met_base.py:525
         try:
             self.T_air
         except AttributeError:
-            self.T_air = 0.0  # iffy: T_air <= 0 needed for P_snow
+            self.T_air = np.float64(0.0)  # iffy: T_air <= 0 needed for P_snow
         try:
             self.rho_air
         except AttributeError:
-            self.rho_air = 1.2614  # met_base.py:526
+            self.rho_air = np.float64(1.2614)  # met_base.py:526
         try:
             self.Cp_air
         except AttributeError:
-            self.Cp_air = 1005.7  # met_base.py:527
+            self.Cp_air = np.float64(1005.7)  # met_base.py:527
         try:
             self.T_surf
         except AttributeError:
@@ -191,7 +191,7 @@ class snow_component( BMI_base.BMI_component ):
         try:
             self.Q_sum
         except AttributeError:
-            self.Q_sum = 0.0  # iffy: from init in met_base.py
+            self.Q_sum = np.float64(0.0)  # iffy: from init in met_base.py
 
         #---------------------------
         # Initialize computed vars

--- a/topoflow/examples/Treynor_Iowa/June_20_67_diversions_fraction_method.cfg
+++ b/topoflow/examples/Treynor_Iowa/June_20_67_diversions_fraction_method.cfg
@@ -2,7 +2,7 @@
 # TopoFlow Config File for: Diversions_Fraction_Method
 #===============================================================================
 # Input
-comp_status         | Disabled      | string    | component status {Enabled; Disabled}
+comp_status         | Enabled      | string    | component status {Enabled; Disabled}
 in_directory        | .     | string    | input directory
 out_directory       | ~/TopoFlow_Tests/Test1    | string    | output directory
 site_prefix         | Treynor      | string    | file prefix for the study site

--- a/topoflow/examples/Treynor_Iowa/June_20_67_evap_read_file.cfg
+++ b/topoflow/examples/Treynor_Iowa/June_20_67_evap_read_file.cfg
@@ -1,0 +1,21 @@
+#===============================================================================
+# TopoFlow Config File for: Evap_Read_file
+#===============================================================================
+# Input
+comp_status         | Enabled      | string  | component status {Enabled; Disabled}
+in_directory        | .     | string    | input directory
+out_directory       | ~/TopoFlow_Tests/Test1    | string    | output directory
+site_prefix         | Treynor      | string    | file prefix for the study site
+case_prefix         | June_20_67      | string    | file prefix for the model scenario
+n_steps             | 10           | long    | number of time steps
+dt                  | 3600.0       | float   | evaporation process timestep [sec]
+ET_rate             | [case_prefix]_2D-ETrate-in.nc           | string    | Grid sequence [mm/hr]
+#===============================================================================
+# Output
+save_grid_dt        | 60.0                        | float   | time interval between saved grids [sec]
+SAVE_ER_GRIDS       | No                          | string  | option to save grids of evap. rate [mm/hr] {Yes; No}
+er_gs_file          | [case_prefix]_2D-ETrate.nc  | string  | filename for grid stack of evap. rate [mm/hr]
+save_pixels_dt      | 60.0                        | float   | time interval between time series values [sec]
+pixel_file          | [case_prefix]_outlets.txt   | string  | filename for monitored pixel info
+SAVE_ER_PIXELS      | No                          | string  | option to save time series of evap. rate {Yes; No}
+er_ts_file          | [case_prefix]_0D-ETrate.txt | string  | filename for time series of evap. rate [mm/hr]

--- a/topoflow/examples/Treynor_Iowa/June_20_67_ice_valley_glacier.cfg
+++ b/topoflow/examples/Treynor_Iowa/June_20_67_ice_valley_glacier.cfg
@@ -2,7 +2,7 @@
 # TopoFlow Config File for: Ice_GC2D
 #===============================================================================
 # Input 1
-comp_status         | Disabled      | string    | component status {Enabled; Disabled}
+comp_status         | Enabled      | string    | component status {Enabled; Disabled}
 in_directory        | .     | string    | input directory
 out_directory       | ~/TopoFlow_Tests/Test1    | string    | output directory
 site_prefix         | Treynor      | string    | file prefix for the study site

--- a/topoflow/examples/Treynor_Iowa/June_20_67_satzone_darcy_layers.cfg
+++ b/topoflow/examples/Treynor_Iowa/June_20_67_satzone_darcy_layers.cfg
@@ -2,7 +2,7 @@
 # TopoFlow Config File for: Satzone_Darcy_Layers
 #===============================================================================
 # Input
-comp_status         | Disabled    | string   | component status {Enabled; Disabled}
+comp_status         | Enabled    | string   | component status {Enabled; Disabled}
 in_directory        | .           | string   | input directory
 out_directory       | ~/TopoFlow_Tests/Test1 | string    | output directory
 site_prefix         | Treynor     | string   | file prefix for the study site

--- a/topoflow/tests/__init__.py
+++ b/topoflow/tests/__init__.py
@@ -5,3 +5,4 @@ from os.path import join, dirname, realpath, expanduser
 
 input_dir = join(dirname(realpath(__file__)), '..', 'examples', 'Treynor_Iowa')
 output_dir = join(expanduser('~'), 'TopoFlow_Tests', 'Test1')
+time_factor = 5.0

--- a/topoflow/tests/__init__.py
+++ b/topoflow/tests/__init__.py
@@ -1,0 +1,7 @@
+"""Nosetests for TopoFlow components."""
+
+from os.path import join, dirname, realpath, expanduser
+
+
+input_dir = join(dirname(realpath(__file__)), '..', 'examples', 'Treynor_Iowa')
+output_dir = join(expanduser('~'), 'TopoFlow_Tests', 'Test1')

--- a/topoflow/tests/test_channels_diffusive_wave.py
+++ b/topoflow/tests/test_channels_diffusive_wave.py
@@ -18,9 +18,13 @@ from os import makedirs, listdir
 from os.path import join, dirname, exists
 from shutil import rmtree
 from nose.tools import assert_is_instance, assert_is_not_none
+from numpy.testing import assert_almost_equal
 from topoflow.components.channels_diffusive_wave \
     import channels_component as Model
-from . import input_dir, output_dir
+from . import input_dir, output_dir, time_factor
+
+
+cfg_file = join(input_dir, 'June_20_67_channels_diffusive_wave.cfg')
 
 
 def setup_module():
@@ -41,7 +45,6 @@ def test_is_instance():
 
 
 def test_irf():
-    cfg_file = join(input_dir, 'June_20_67_channels_diffusive_wave.cfg')
     comp.initialize(cfg_file)
     comp.update()
     comp.finalize()
@@ -49,3 +52,25 @@ def test_irf():
 
 def test_has_output():
     assert_is_not_none(listdir(output_dir))
+
+
+def test_update_frac():
+    time_step = comp.get_time_step()
+    frac_time = 1.0 / time_factor
+
+    comp.initialize(cfg_file)
+    comp.update_frac(frac_time)
+    end_time = comp.get_current_time()
+    comp.finalize()
+    assert_almost_equal(end_time, frac_time*time_step)
+
+
+def test_update_until():
+    time_step = comp.get_time_step()
+    until_time = time_step*time_factor + time_step/time_factor
+
+    comp.initialize(cfg_file)
+    comp.update_until(until_time)
+    end_time = comp.get_current_time()
+    comp.finalize()
+    assert_almost_equal(end_time, until_time)

--- a/topoflow/tests/test_channels_diffusive_wave.py
+++ b/topoflow/tests/test_channels_diffusive_wave.py
@@ -18,7 +18,6 @@ from os import makedirs, listdir
 from os.path import join, dirname, exists
 from shutil import rmtree
 from nose.tools import assert_is_instance, assert_is_not_none
-import numpy as np
 from topoflow.components.channels_diffusive_wave \
     import channels_component as Model
 from . import input_dir, output_dir

--- a/topoflow/tests/test_channels_diffusive_wave.py
+++ b/topoflow/tests/test_channels_diffusive_wave.py
@@ -19,13 +19,14 @@ from os.path import join, dirname, exists
 from shutil import rmtree
 from nose.tools import assert_is_instance, assert_is_not_none
 import numpy as np
-from topoflow.components.channels_diffusive_wave import channels_component
+from topoflow.components.channels_diffusive_wave \
+    import channels_component as Model
 from . import input_dir, output_dir
 
 
 def setup_module():
     global comp
-    comp = channels_component()
+    comp = Model()
     if not exists(output_dir):
         makedirs(output_dir)
 
@@ -37,7 +38,7 @@ def teardown_module():
 
 
 def test_is_instance():
-    assert_is_instance(comp, channels_component)
+    assert_is_instance(comp, Model)
 
 
 def test_irf():

--- a/topoflow/tests/test_channels_diffusive_wave.py
+++ b/topoflow/tests/test_channels_diffusive_wave.py
@@ -43,17 +43,6 @@ def test_is_instance():
 
 def test_irf():
     cfg_file = join(input_dir, 'June_20_67_channels_diffusive_wave.cfg')
-
-    # @mperignon found these attributes are needed but not provided.
-    comp.P_rain = 100
-    comp.SM = 0
-    comp.ET = 0
-    comp.GW = 0
-    comp.IN = 0
-    comp.MR = 0
-    comp.rho_H2O = 1000
-    comp.S_free = np.zeros((44, 29))  # shape from Treynor.rti
-
     comp.initialize(cfg_file)
     comp.update()
     comp.finalize()

--- a/topoflow/tests/test_channels_diffusive_wave.py
+++ b/topoflow/tests/test_channels_diffusive_wave.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+#
+# Tests the ChannelsDiffWave TopoFlow component.
+#
+# site_prefix = 'Treynor'
+# case_prefix = 'June_20_67'
+#
+# Required input files:
+# - June_20_67_channels_diffusive_wave.cfg
+# - Treynor.rti
+# - Treynor_slope.rtg
+# - Treynor_chan-a.rtg
+# - Treynor_chan-n.rtg
+# - Treynor_chan-w.rtg
+# - Treynor_flow.rtg
+
+from os import makedirs, listdir
+from os.path import join, dirname, exists
+from shutil import rmtree
+from nose.tools import assert_is_instance, assert_is_not_none
+import numpy as np
+from topoflow.components.channels_diffusive_wave import channels_component
+from . import input_dir, output_dir
+
+
+def setup_module():
+    global comp
+    comp = channels_component()
+    if not exists(output_dir):
+        makedirs(output_dir)
+
+
+def teardown_module():
+    parent_dir = dirname(output_dir)
+    if exists(parent_dir):
+        rmtree(parent_dir)
+
+
+def test_is_instance():
+    assert_is_instance(comp, channels_component)
+
+
+def test_irf():
+    cfg_file = join(input_dir, 'June_20_67_channels_diffusive_wave.cfg')
+
+    # @mperignon found these attributes are needed but not provided.
+    comp.P_rain = 100
+    comp.SM = 0
+    comp.ET = 0
+    comp.GW = 0
+    comp.IN = 0
+    comp.MR = 0
+    comp.rho_H2O = 1000
+    comp.S_free = np.zeros((44, 29))  # shape from Treynor.rti
+
+    comp.initialize(cfg_file)
+    comp.update()
+    comp.finalize()
+
+
+def test_has_output():
+    assert_is_not_none(listdir(output_dir))

--- a/topoflow/tests/test_channels_dynamic_wave.py
+++ b/topoflow/tests/test_channels_dynamic_wave.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+#
+# Tests the ChannelsDynamWave TopoFlow component.
+#
+# site_prefix = 'Treynor'
+# case_prefix = 'June_20_67'
+#
+# Required input files:
+# - June_20_67_channels_dynamic_wave.cfg
+# - Treynor.rti
+# - Treynor_slope.rtg
+# - Treynor_chan-a.rtg
+# - Treynor_chan-n.rtg
+# - Treynor_chan-w.rtg
+# - Treynor_flow.rtg
+
+from os import makedirs, listdir
+from os.path import join, dirname, exists
+from shutil import rmtree
+import numpy as np
+from nose.tools import raises, assert_is_instance, assert_is_not_none
+from topoflow.components.channels_dynamic_wave import channels_component
+from . import input_dir, output_dir
+
+
+def setup_module():
+    global comp
+    comp = channels_component()
+    if not exists(output_dir):
+        makedirs(output_dir)
+
+
+def teardown_module():
+    parent_dir = dirname(output_dir)
+    if exists(parent_dir):
+        rmtree(parent_dir)
+
+
+def test_is_instance():
+    assert_is_instance(comp, channels_component)
+
+
+# The variable 'dinv' is undefined in channels_dynamic_wave.py.
+@raises(NameError)
+def test_irf():
+    cfg_file = join(input_dir, 'June_20_67_channels_dynamic_wave.cfg')
+
+    # @mperignon found these attributes are needed but not provided.
+    comp.P_rain = 100
+    comp.SM = 0
+    comp.ET = 0
+    comp.GW = 0
+    comp.IN = 0
+    comp.MR = 0
+    comp.rho_H2O = 1000
+    comp.S_free = np.zeros((44, 29))  # shape from Treynor.rti
+
+    comp.initialize(cfg_file)
+    comp.update()
+    comp.finalize()
+
+
+def test_has_output():
+    assert_is_not_none(listdir(output_dir))

--- a/topoflow/tests/test_channels_dynamic_wave.py
+++ b/topoflow/tests/test_channels_dynamic_wave.py
@@ -18,7 +18,7 @@ from os import makedirs, listdir
 from os.path import join, dirname, exists
 from shutil import rmtree
 import numpy as np
-from nose.tools import raises, assert_is_instance, assert_is_not_none
+from nose.tools import assert_is_instance, assert_is_not_none
 from topoflow.components.channels_dynamic_wave \
     import channels_component as Model
 from . import input_dir, output_dir
@@ -41,8 +41,6 @@ def test_is_instance():
     assert_is_instance(comp, Model)
 
 
-# The variable 'dinv' is undefined in channels_dynamic_wave.py.
-@raises(NameError)
 def test_irf():
     cfg_file = join(input_dir, 'June_20_67_channels_dynamic_wave.cfg')
     comp.initialize(cfg_file)

--- a/topoflow/tests/test_channels_dynamic_wave.py
+++ b/topoflow/tests/test_channels_dynamic_wave.py
@@ -18,9 +18,13 @@ from os import makedirs, listdir
 from os.path import join, dirname, exists
 from shutil import rmtree
 from nose.tools import assert_is_instance, assert_is_not_none
+from numpy.testing import assert_almost_equal
 from topoflow.components.channels_dynamic_wave \
     import channels_component as Model
-from . import input_dir, output_dir
+from . import input_dir, output_dir, time_factor
+
+
+cfg_file = join(input_dir, 'June_20_67_channels_dynamic_wave.cfg')
 
 
 def setup_module():
@@ -41,7 +45,6 @@ def test_is_instance():
 
 
 def test_irf():
-    cfg_file = join(input_dir, 'June_20_67_channels_dynamic_wave.cfg')
     comp.initialize(cfg_file)
     comp.update()
     comp.finalize()
@@ -49,3 +52,25 @@ def test_irf():
 
 def test_has_output():
     assert_is_not_none(listdir(output_dir))
+
+
+def test_update_frac():
+    time_step = comp.get_time_step()
+    frac_time = 1.0 / time_factor
+
+    comp.initialize(cfg_file)
+    comp.update_frac(frac_time)
+    end_time = comp.get_current_time()
+    comp.finalize()
+    assert_almost_equal(end_time, frac_time*time_step)
+
+
+def test_update_until():
+    time_step = comp.get_time_step()
+    until_time = time_step*time_factor + time_step/time_factor
+
+    comp.initialize(cfg_file)
+    comp.update_until(until_time)
+    end_time = comp.get_current_time()
+    comp.finalize()
+    assert_almost_equal(end_time, until_time)

--- a/topoflow/tests/test_channels_dynamic_wave.py
+++ b/topoflow/tests/test_channels_dynamic_wave.py
@@ -17,7 +17,6 @@
 from os import makedirs, listdir
 from os.path import join, dirname, exists
 from shutil import rmtree
-import numpy as np
 from nose.tools import assert_is_instance, assert_is_not_none
 from topoflow.components.channels_dynamic_wave \
     import channels_component as Model

--- a/topoflow/tests/test_channels_dynamic_wave.py
+++ b/topoflow/tests/test_channels_dynamic_wave.py
@@ -45,17 +45,6 @@ def test_is_instance():
 @raises(NameError)
 def test_irf():
     cfg_file = join(input_dir, 'June_20_67_channels_dynamic_wave.cfg')
-
-    # @mperignon found these attributes are needed but not provided.
-    comp.P_rain = 100
-    comp.SM = 0
-    comp.ET = 0
-    comp.GW = 0
-    comp.IN = 0
-    comp.MR = 0
-    comp.rho_H2O = 1000
-    comp.S_free = np.zeros((44, 29))  # shape from Treynor.rti
-
     comp.initialize(cfg_file)
     comp.update()
     comp.finalize()

--- a/topoflow/tests/test_channels_dynamic_wave.py
+++ b/topoflow/tests/test_channels_dynamic_wave.py
@@ -19,13 +19,14 @@ from os.path import join, dirname, exists
 from shutil import rmtree
 import numpy as np
 from nose.tools import raises, assert_is_instance, assert_is_not_none
-from topoflow.components.channels_dynamic_wave import channels_component
+from topoflow.components.channels_dynamic_wave \
+    import channels_component as Model
 from . import input_dir, output_dir
 
 
 def setup_module():
     global comp
-    comp = channels_component()
+    comp = Model()
     if not exists(output_dir):
         makedirs(output_dir)
 
@@ -37,7 +38,7 @@ def teardown_module():
 
 
 def test_is_instance():
-    assert_is_instance(comp, channels_component)
+    assert_is_instance(comp, Model)
 
 
 # The variable 'dinv' is undefined in channels_dynamic_wave.py.

--- a/topoflow/tests/test_channels_kinematic_wave.py
+++ b/topoflow/tests/test_channels_kinematic_wave.py
@@ -42,16 +42,6 @@ def test_is_instance():
 
 def test_irf():
     cfg_file = join(input_dir, 'June_20_67_channels_kinematic_wave.cfg')
-
-    # @mperignon found these attributes are needed but not provided.
-    comp.P_rain = 100
-    comp.SM = 0
-    comp.ET = 0
-    comp.GW = 0
-    comp.IN = 0
-    comp.MR = 0
-    comp.rho_H2O = 1000
-
     comp.initialize(cfg_file)
     comp.update()
     comp.finalize()

--- a/topoflow/tests/test_channels_kinematic_wave.py
+++ b/topoflow/tests/test_channels_kinematic_wave.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+#
+# Tests the ChannelsKinWave TopoFlow component.
+#
+# site_prefix = 'Treynor'
+# case_prefix = 'June_20_67'
+#
+# Required input files:
+# - June_20_67_channels_kinematic_wave.cfg
+# - Treynor.rti
+# - Treynor_slope.rtg
+# - Treynor_chan-a.rtg
+# - Treynor_chan-n.rtg
+# - Treynor_chan-w.rtg
+# - Treynor_flow.rtg
+
+from os import makedirs, listdir
+from os.path import join, dirname, exists
+from shutil import rmtree
+from nose.tools import assert_is_instance, assert_is_not_none
+from topoflow.components.channels_kinematic_wave import channels_component
+from . import input_dir, output_dir
+
+
+def setup_module():
+    global comp
+    comp = channels_component()
+    if not exists(output_dir):
+        makedirs(output_dir)
+
+
+def teardown_module():
+    parent_dir = dirname(output_dir)
+    if exists(parent_dir):
+        rmtree(parent_dir)
+
+
+def test_is_instance():
+    assert_is_instance(comp, channels_component)
+
+
+def test_irf():
+    cfg_file = join(input_dir, 'June_20_67_channels_kinematic_wave.cfg')
+
+    # @mperignon found these attributes are needed but not provided.
+    comp.P_rain = 100
+    comp.SM = 0
+    comp.ET = 0
+    comp.GW = 0
+    comp.IN = 0
+    comp.MR = 0
+    comp.rho_H2O = 1000
+
+    comp.initialize(cfg_file)
+    comp.update()
+    comp.finalize()
+
+
+def test_has_output():
+    assert_is_not_none(listdir(output_dir))

--- a/topoflow/tests/test_channels_kinematic_wave.py
+++ b/topoflow/tests/test_channels_kinematic_wave.py
@@ -18,13 +18,14 @@ from os import makedirs, listdir
 from os.path import join, dirname, exists
 from shutil import rmtree
 from nose.tools import assert_is_instance, assert_is_not_none
-from topoflow.components.channels_kinematic_wave import channels_component
+from topoflow.components.channels_kinematic_wave \
+    import channels_component as Model
 from . import input_dir, output_dir
 
 
 def setup_module():
     global comp
-    comp = channels_component()
+    comp = Model()
     if not exists(output_dir):
         makedirs(output_dir)
 
@@ -36,7 +37,7 @@ def teardown_module():
 
 
 def test_is_instance():
-    assert_is_instance(comp, channels_component)
+    assert_is_instance(comp, Model)
 
 
 def test_irf():

--- a/topoflow/tests/test_channels_kinematic_wave.py
+++ b/topoflow/tests/test_channels_kinematic_wave.py
@@ -18,9 +18,13 @@ from os import makedirs, listdir
 from os.path import join, dirname, exists
 from shutil import rmtree
 from nose.tools import assert_is_instance, assert_is_not_none
+from numpy.testing import assert_almost_equal
 from topoflow.components.channels_kinematic_wave \
     import channels_component as Model
-from . import input_dir, output_dir
+from . import input_dir, output_dir, time_factor
+
+
+cfg_file = join(input_dir, 'June_20_67_channels_kinematic_wave.cfg')
 
 
 def setup_module():
@@ -41,7 +45,6 @@ def test_is_instance():
 
 
 def test_irf():
-    cfg_file = join(input_dir, 'June_20_67_channels_kinematic_wave.cfg')
     comp.initialize(cfg_file)
     comp.update()
     comp.finalize()
@@ -49,3 +52,25 @@ def test_irf():
 
 def test_has_output():
     assert_is_not_none(listdir(output_dir))
+
+
+def test_update_frac():
+    time_step = comp.get_time_step()
+    frac_time = 1.0 / time_factor
+
+    comp.initialize(cfg_file)
+    comp.update_frac(frac_time)
+    end_time = comp.get_current_time()
+    comp.finalize()
+    assert_almost_equal(end_time, frac_time*time_step)
+
+
+def test_update_until():
+    time_step = comp.get_time_step()
+    until_time = time_step*time_factor + time_step/time_factor
+
+    comp.initialize(cfg_file)
+    comp.update_until(until_time)
+    end_time = comp.get_current_time()
+    comp.finalize()
+    assert_almost_equal(end_time, until_time)

--- a/topoflow/tests/test_diversions_fraction_method.py
+++ b/topoflow/tests/test_diversions_fraction_method.py
@@ -13,9 +13,13 @@ from shutil import rmtree
 from os import makedirs, listdir
 from os.path import join, dirname, exists
 from nose.tools import raises, assert_is_instance, assert_is_not_none
+from numpy.testing import assert_almost_equal
 from topoflow.components.diversions_fraction_method \
     import diversions_component as Model
-from . import input_dir, output_dir
+from . import input_dir, output_dir, time_factor
+
+
+cfg_file = join(input_dir, 'June_20_67_diversions_fraction_method.cfg')
 
 
 def setup_module():
@@ -36,8 +40,6 @@ def test_is_instance():
 
 
 def test_irf():
-    cfg_file = join(input_dir, 'June_20_67_diversions_fraction_method.cfg')
-
     comp.initialize(cfg_file)
     comp.update()
     comp.finalize()
@@ -45,3 +47,25 @@ def test_irf():
 
 def test_has_output():
     assert_is_not_none(listdir(output_dir))
+
+
+def test_update_frac():
+    time_step = comp.get_time_step()
+    frac_time = 1.0 / time_factor
+
+    comp.initialize(cfg_file)
+    comp.update_frac(frac_time)
+    end_time = comp.get_current_time()
+    comp.finalize()
+    assert_almost_equal(end_time, frac_time*time_step)
+
+
+def test_update_until():
+    time_step = comp.get_time_step()
+    until_time = time_step*time_factor + time_step/time_factor
+
+    comp.initialize(cfg_file)
+    comp.update_until(until_time)
+    end_time = comp.get_current_time()
+    comp.finalize()
+    assert_almost_equal(end_time, until_time)

--- a/topoflow/tests/test_diversions_fraction_method.py
+++ b/topoflow/tests/test_diversions_fraction_method.py
@@ -13,13 +13,14 @@ from shutil import rmtree
 from os import makedirs, listdir
 from os.path import join, dirname, exists
 from nose.tools import raises, assert_is_instance, assert_is_not_none
-from topoflow.components.diversions_fraction_method import diversions_component
+from topoflow.components.diversions_fraction_method \
+    import diversions_component as Model
 from . import input_dir, output_dir
 
 
 def setup_module():
     global comp
-    comp = diversions_component()
+    comp = Model()
     if not exists(output_dir):
         makedirs(output_dir)
 
@@ -31,7 +32,7 @@ def teardown_module():
 
 
 def test_is_instance():
-    assert_is_instance(comp, diversions_component)
+    assert_is_instance(comp, Model)
 
 
 def test_irf():

--- a/topoflow/tests/test_diversions_fraction_method.py
+++ b/topoflow/tests/test_diversions_fraction_method.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+#
+# Tests the DiversionsFraction TopoFlow component.
+#
+# site_prefix = 'Treynor'
+# case_prefix = 'June_20_67'
+#
+# Required input files:
+# - June_20_67_diversions_fraction_method.cfg
+# - Treynor.rti
+
+from shutil import rmtree
+from os import makedirs, listdir
+from os.path import join, dirname, exists
+from nose.tools import raises, assert_is_instance, assert_is_not_none
+from topoflow.components.diversions_fraction_method import diversions_component
+from . import input_dir, output_dir
+
+
+def setup_module():
+    global comp
+    comp = diversions_component()
+    if not exists(output_dir):
+        makedirs(output_dir)
+
+
+def teardown_module():
+    parent_dir = dirname(output_dir)
+    if exists(parent_dir):
+        rmtree(parent_dir)
+
+
+def test_is_instance():
+    assert_is_instance(comp, diversions_component)
+
+
+def test_irf():
+    cfg_file = join(input_dir, 'June_20_67_diversions_fraction_method.cfg')
+
+    comp.initialize(cfg_file)
+    comp.update()
+    comp.finalize()
+
+
+def test_has_output():
+    assert_is_not_none(listdir(output_dir))

--- a/topoflow/tests/test_diversions_standard.py
+++ b/topoflow/tests/test_diversions_standard.py
@@ -13,13 +13,13 @@ from shutil import rmtree
 from os import makedirs, listdir
 from os.path import join, dirname, exists
 from nose.tools import assert_is_instance, assert_is_not_none
-from topoflow.components.diversions_base import diversions_component
+from topoflow.components.diversions_base import diversions_component as Model
 from . import input_dir, output_dir
 
 
 def setup_module():
     global comp
-    comp = diversions_component()
+    comp = Model()
     if not exists(output_dir):
         makedirs(output_dir)
 
@@ -31,7 +31,7 @@ def teardown_module():
 
 
 def test_is_instance():
-    assert_is_instance(comp, diversions_component)
+    assert_is_instance(comp, Model)
 
 
 def test_irf():

--- a/topoflow/tests/test_diversions_standard.py
+++ b/topoflow/tests/test_diversions_standard.py
@@ -13,8 +13,12 @@ from shutil import rmtree
 from os import makedirs, listdir
 from os.path import join, dirname, exists
 from nose.tools import assert_is_instance, assert_is_not_none
+from numpy.testing import assert_almost_equal
 from topoflow.components.diversions_base import diversions_component as Model
-from . import input_dir, output_dir
+from . import input_dir, output_dir, time_factor
+
+
+cfg_file = join(input_dir, 'June_20_67_diversions_fraction_method.cfg')
 
 
 def setup_module():
@@ -35,8 +39,6 @@ def test_is_instance():
 
 
 def test_irf():
-    cfg_file = join(input_dir, 'June_20_67_diversions_fraction_method.cfg')
-
     comp.initialize(cfg_file)
     comp.update()
     comp.finalize()
@@ -44,3 +46,25 @@ def test_irf():
 
 def test_has_output():
     assert_is_not_none(listdir(output_dir))
+
+
+def test_update_frac():
+    time_step = comp.get_time_step()
+    frac_time = 1.0 / time_factor
+
+    comp.initialize(cfg_file)
+    comp.update_frac(frac_time)
+    end_time = comp.get_current_time()
+    comp.finalize()
+    assert_almost_equal(end_time, frac_time*time_step)
+
+
+def test_update_until():
+    time_step = comp.get_time_step()
+    until_time = time_step*time_factor + time_step/time_factor
+
+    comp.initialize(cfg_file)
+    comp.update_until(until_time)
+    end_time = comp.get_current_time()
+    comp.finalize()
+    assert_almost_equal(end_time, until_time)

--- a/topoflow/tests/test_diversions_standard.py
+++ b/topoflow/tests/test_diversions_standard.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+#
+# Tests the Diversions TopoFlow component.
+#
+# site_prefix = 'Treynor'
+# case_prefix = 'June_20_67'
+#
+# Required input files:
+# - June_20_67_diversions_fraction_method.cfg  # note filename
+# - Treynor.rti
+
+from shutil import rmtree
+from os import makedirs, listdir
+from os.path import join, dirname, exists
+from nose.tools import assert_is_instance, assert_is_not_none
+from topoflow.components.diversions_base import diversions_component
+from . import input_dir, output_dir
+
+
+def setup_module():
+    global comp
+    comp = diversions_component()
+    if not exists(output_dir):
+        makedirs(output_dir)
+
+
+def teardown_module():
+    parent_dir = dirname(output_dir)
+    if exists(parent_dir):
+        rmtree(parent_dir)
+
+
+def test_is_instance():
+    assert_is_instance(comp, diversions_component)
+
+
+def test_irf():
+    cfg_file = join(input_dir, 'June_20_67_diversions_fraction_method.cfg')
+
+    comp.initialize(cfg_file)
+    comp.update()
+    comp.finalize()
+
+
+def test_has_output():
+    assert_is_not_none(listdir(output_dir))

--- a/topoflow/tests/test_evap_energy_balance.py
+++ b/topoflow/tests/test_evap_energy_balance.py
@@ -13,7 +13,6 @@ from shutil import rmtree
 from os import makedirs, listdir
 from os.path import join, dirname, exists
 from nose.tools import assert_is_instance, assert_is_not_none
-import numpy as np
 from topoflow.components.evap_energy_balance import evap_component as Model
 from . import input_dir, output_dir
 

--- a/topoflow/tests/test_evap_energy_balance.py
+++ b/topoflow/tests/test_evap_energy_balance.py
@@ -14,13 +14,13 @@ from os import makedirs, listdir
 from os.path import join, dirname, exists
 from nose.tools import assert_is_instance, assert_is_not_none
 import numpy as np
-from topoflow.components.evap_energy_balance import evap_component
+from topoflow.components.evap_energy_balance import evap_component as Model
 from . import input_dir, output_dir
 
 
 def setup_module():
     global comp
-    comp = evap_component()
+    comp = Model()
     if not exists(output_dir):
         makedirs(output_dir)
 
@@ -32,7 +32,7 @@ def teardown_module():
 
 
 def test_is_instance():
-    assert_is_instance(comp, evap_component)
+    assert_is_instance(comp, Model)
 
 
 def test_irf():

--- a/topoflow/tests/test_evap_energy_balance.py
+++ b/topoflow/tests/test_evap_energy_balance.py
@@ -37,14 +37,6 @@ def test_is_instance():
 
 def test_irf():
     cfg_file = join(input_dir, 'June_20_67_evap_energy_balance.cfg')
-
-    # @mperignon found these attributes are needed but not provided.
-    comp.h_snow = 1
-    comp.Q_sum = 1
-    comp.Qe = 1
-    comp.T_air = 10
-    comp.T_surf = 20
-
     comp.initialize(cfg_file)
     comp.update()
     comp.finalize()

--- a/topoflow/tests/test_evap_energy_balance.py
+++ b/topoflow/tests/test_evap_energy_balance.py
@@ -13,8 +13,12 @@ from shutil import rmtree
 from os import makedirs, listdir
 from os.path import join, dirname, exists
 from nose.tools import assert_is_instance, assert_is_not_none
+from numpy.testing import assert_almost_equal
 from topoflow.components.evap_energy_balance import evap_component as Model
-from . import input_dir, output_dir
+from . import input_dir, output_dir, time_factor
+
+
+cfg_file = join(input_dir, 'June_20_67_evap_energy_balance.cfg')
 
 
 def setup_module():
@@ -35,7 +39,6 @@ def test_is_instance():
 
 
 def test_irf():
-    cfg_file = join(input_dir, 'June_20_67_evap_energy_balance.cfg')
     comp.initialize(cfg_file)
     comp.update()
     comp.finalize()
@@ -43,3 +46,25 @@ def test_irf():
 
 def test_has_output():
     assert_is_not_none(listdir(output_dir))
+
+
+def test_update_frac():
+    time_step = comp.get_time_step()
+    frac_time = 1.0 / time_factor
+
+    comp.initialize(cfg_file)
+    comp.update_frac(frac_time)
+    end_time = comp.get_current_time()
+    comp.finalize()
+    assert_almost_equal(end_time, frac_time*time_step)
+
+
+def test_update_until():
+    time_step = comp.get_time_step()
+    until_time = time_step*time_factor + time_step/time_factor
+
+    comp.initialize(cfg_file)
+    comp.update_until(until_time)
+    end_time = comp.get_current_time()
+    comp.finalize()
+    assert_almost_equal(end_time, until_time)

--- a/topoflow/tests/test_evap_energy_balance.py
+++ b/topoflow/tests/test_evap_energy_balance.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+#
+# Tests the EvapEnergyBalance TopoFlow component.
+#
+# site_prefix = 'Treynor'
+# case_prefix = 'June_20_67'
+#
+# Required input files:
+# - June_20_67_evap_energy_balance.cfg
+# - Treynor.rti
+
+from shutil import rmtree
+from os import makedirs, listdir
+from os.path import join, dirname, exists
+from nose.tools import assert_is_instance, assert_is_not_none
+import numpy as np
+from topoflow.components.evap_energy_balance import evap_component
+from . import input_dir, output_dir
+
+
+def setup_module():
+    global comp
+    comp = evap_component()
+    if not exists(output_dir):
+        makedirs(output_dir)
+
+
+def teardown_module():
+    parent_dir = dirname(output_dir)
+    if exists(parent_dir):
+        rmtree(parent_dir)
+
+
+def test_is_instance():
+    assert_is_instance(comp, evap_component)
+
+
+def test_irf():
+    cfg_file = join(input_dir, 'June_20_67_evap_energy_balance.cfg')
+
+    # @mperignon found these attributes are needed but not provided.
+    comp.h_snow = 1
+    comp.Q_sum = 1
+    comp.Qe = 1
+    comp.T_air = 10
+    comp.T_surf = 20
+
+    comp.initialize(cfg_file)
+    comp.update()
+    comp.finalize()
+
+
+def test_has_output():
+    assert_is_not_none(listdir(output_dir))

--- a/topoflow/tests/test_evap_priestley_taylor.py
+++ b/topoflow/tests/test_evap_priestley_taylor.py
@@ -13,13 +13,13 @@ from shutil import rmtree
 from os import makedirs, listdir
 from os.path import join, dirname, exists
 from nose.tools import assert_is_instance, assert_is_not_none
-from topoflow.components.evap_priestley_taylor import evap_component
+from topoflow.components.evap_priestley_taylor import evap_component as Model
 from . import input_dir, output_dir
 
 
 def setup_module():
     global comp
-    comp = evap_component()
+    comp = Model()
     if exists(output_dir) is False:
         makedirs(output_dir)
 
@@ -31,7 +31,7 @@ def teardown_module():
 
 
 def test_is_instance():
-    assert_is_instance(comp, evap_component)
+    assert_is_instance(comp, Model)
 
 
 def test_irf():

--- a/topoflow/tests/test_evap_priestley_taylor.py
+++ b/topoflow/tests/test_evap_priestley_taylor.py
@@ -36,13 +36,6 @@ def test_is_instance():
 
 def test_irf():
     cfg_file = join(input_dir, 'June_20_67_evap_priestley_taylor.cfg')
-
-    # @mperignon found these attributes are needed but not provided.
-    comp.Qn_SW = 1
-    comp.Qn_LW = 1
-    comp.T_air = 10
-    comp.T_surf = 20
-
     comp.initialize(cfg_file)
     comp.update()
     comp.finalize()

--- a/topoflow/tests/test_evap_priestley_taylor.py
+++ b/topoflow/tests/test_evap_priestley_taylor.py
@@ -13,8 +13,12 @@ from shutil import rmtree
 from os import makedirs, listdir
 from os.path import join, dirname, exists
 from nose.tools import assert_is_instance, assert_is_not_none
+from numpy.testing import assert_almost_equal
 from topoflow.components.evap_priestley_taylor import evap_component as Model
-from . import input_dir, output_dir
+from . import input_dir, output_dir, time_factor
+
+
+cfg_file = join(input_dir, 'June_20_67_evap_priestley_taylor.cfg')
 
 
 def setup_module():
@@ -35,7 +39,6 @@ def test_is_instance():
 
 
 def test_irf():
-    cfg_file = join(input_dir, 'June_20_67_evap_priestley_taylor.cfg')
     comp.initialize(cfg_file)
     comp.update()
     comp.finalize()
@@ -43,3 +46,25 @@ def test_irf():
 
 def test_has_output():
     assert_is_not_none(listdir(output_dir))
+
+
+def test_update_frac():
+    time_step = comp.get_time_step()
+    frac_time = 1.0 / time_factor
+
+    comp.initialize(cfg_file)
+    comp.update_frac(frac_time)
+    end_time = comp.get_current_time()
+    comp.finalize()
+    assert_almost_equal(end_time, frac_time*time_step)
+
+
+def test_update_until():
+    time_step = comp.get_time_step()
+    until_time = time_step*time_factor + time_step/time_factor
+
+    comp.initialize(cfg_file)
+    comp.update_until(until_time)
+    end_time = comp.get_current_time()
+    comp.finalize()
+    assert_almost_equal(end_time, until_time)

--- a/topoflow/tests/test_evap_priestley_taylor.py
+++ b/topoflow/tests/test_evap_priestley_taylor.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+#
+# Tests the EvapPriestleyTaylor TopoFlow component.
+#
+# site_prefix = 'Treynor'
+# case_prefix = 'June_20_67'
+#
+# Required input files:
+# - June_20_67_evap_priestley_taylor.cfg
+# - Treynor.rti
+
+from shutil import rmtree
+from os import makedirs, listdir
+from os.path import join, dirname, exists
+from nose.tools import assert_is_instance, assert_is_not_none
+from topoflow.components.evap_priestley_taylor import evap_component
+from . import input_dir, output_dir
+
+
+def setup_module():
+    global comp
+    comp = evap_component()
+    if exists(output_dir) is False:
+        makedirs(output_dir)
+
+
+def teardown_module():
+    parent_dir = dirname(output_dir)
+    if exists(parent_dir):
+        rmtree(parent_dir)
+
+
+def test_is_instance():
+    assert_is_instance(comp, evap_component)
+
+
+def test_irf():
+    cfg_file = join(input_dir, 'June_20_67_evap_priestley_taylor.cfg')
+
+    # @mperignon found these attributes are needed but not provided.
+    comp.Qn_SW = 1
+    comp.Qn_LW = 1
+    comp.T_air = 10
+    comp.T_surf = 20
+
+    comp.initialize(cfg_file)
+    comp.update()
+    comp.finalize()
+
+
+def test_has_output():
+    assert_is_not_none(listdir(output_dir))

--- a/topoflow/tests/test_evap_read_file.py
+++ b/topoflow/tests/test_evap_read_file.py
@@ -14,7 +14,6 @@ from shutil import rmtree
 from os import makedirs, listdir
 from os.path import join, dirname, exists
 from nose.tools import raises, assert_is_instance, assert_is_not_none
-import numpy as np
 from topoflow.components.evap_read_file import evap_component as Model
 from . import input_dir, output_dir
 

--- a/topoflow/tests/test_evap_read_file.py
+++ b/topoflow/tests/test_evap_read_file.py
@@ -15,13 +15,13 @@ from os import makedirs, listdir
 from os.path import join, dirname, exists
 from nose.tools import raises, assert_is_instance, assert_is_not_none
 import numpy as np
-from topoflow.components.evap_read_file import evap_component
+from topoflow.components.evap_read_file import evap_component as Model
 from . import input_dir, output_dir
 
 
 def setup_module():
     global comp
-    comp = evap_component()
+    comp = Model()
     if not exists(output_dir):
         makedirs(output_dir)
 
@@ -33,7 +33,7 @@ def teardown_module():
 
 
 def test_is_instance():
-    assert_is_instance(comp, evap_component)
+    assert_is_instance(comp, Model)
 
 
 # The file '[case_prefix]_2D-ETrate-in.nc' is missing.

--- a/topoflow/tests/test_evap_read_file.py
+++ b/topoflow/tests/test_evap_read_file.py
@@ -13,9 +13,13 @@
 from shutil import rmtree
 from os import makedirs, listdir
 from os.path import join, dirname, exists
-from nose.tools import raises, assert_is_instance, assert_is_not_none
+from nose.tools import assert_is_instance, assert_is_not_none
+from numpy.testing import assert_almost_equal
 from topoflow.components.evap_read_file import evap_component as Model
-from . import input_dir, output_dir
+from . import input_dir, output_dir, time_factor
+
+
+cfg_file = join(input_dir, 'June_20_67_evap_read_file.cfg')
 
 
 def setup_module():
@@ -35,11 +39,8 @@ def test_is_instance():
     assert_is_instance(comp, Model)
 
 
-# The file '[case_prefix]_2D-ETrate-in.nc' is missing.
-@raises(AttributeError)
+# TODO: The file '[case_prefix]_2D-ETrate-in.nc' is missing.
 def test_irf():
-    cfg_file = join(input_dir, 'June_20_67_evap_read_file.cfg')
-
     comp.initialize(cfg_file)
     comp.update()
     comp.finalize()
@@ -47,3 +48,27 @@ def test_irf():
 
 def test_has_output():
     assert_is_not_none(listdir(output_dir))
+
+
+# TODO: The file '[case_prefix]_2D-ETrate-in.nc' is missing.
+def test_update_frac():
+    time_step = comp.get_time_step()
+    frac_time = 1.0 / time_factor
+
+    comp.initialize(cfg_file)
+    comp.update_frac(frac_time)
+    end_time = comp.get_current_time()
+    comp.finalize()
+    assert_almost_equal(end_time, frac_time*time_step)
+
+
+# TODO: The file '[case_prefix]_2D-ETrate-in.nc' is missing.
+def test_update_until():
+    time_step = comp.get_time_step()
+    until_time = time_step*time_factor + time_step/time_factor
+
+    comp.initialize(cfg_file)
+    comp.update_until(until_time)
+    end_time = comp.get_current_time()
+    comp.finalize()
+    assert_almost_equal(end_time, until_time)

--- a/topoflow/tests/test_evap_read_file.py
+++ b/topoflow/tests/test_evap_read_file.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+#
+# Tests the EvapReadFile TopoFlow component.
+#
+# site_prefix = 'Treynor'
+# case_prefix = 'June_20_67'
+#
+# Required input files:
+# - June_20_67_evap_read_file.cfg
+# - Treynor.rti
+# - June_20_67_2D-ETrate-in.nc
+
+from shutil import rmtree
+from os import makedirs, listdir
+from os.path import join, dirname, exists
+from nose.tools import raises, assert_is_instance, assert_is_not_none
+import numpy as np
+from topoflow.components.evap_read_file import evap_component
+from . import input_dir, output_dir
+
+
+def setup_module():
+    global comp
+    comp = evap_component()
+    if not exists(output_dir):
+        makedirs(output_dir)
+
+
+def teardown_module():
+    parent_dir = dirname(output_dir)
+    if exists(parent_dir):
+        rmtree(parent_dir)
+
+
+def test_is_instance():
+    assert_is_instance(comp, evap_component)
+
+
+# The file '[case_prefix]_2D-ETrate-in.nc' is missing.
+@raises(AttributeError)
+def test_irf():
+    cfg_file = join(input_dir, 'June_20_67_evap_read_file.cfg')
+
+    comp.initialize(cfg_file)
+    comp.update()
+    comp.finalize()
+
+
+def test_has_output():
+    assert_is_not_none(listdir(output_dir))

--- a/topoflow/tests/test_ice_gc2d.py
+++ b/topoflow/tests/test_ice_gc2d.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+#
+# Tests the GC2D TopoFlow component.
+#
+# site_prefix = 'Treynor'
+# case_prefix = 'June_20_67'
+#
+# Required input files:
+# - June_20_67_ice_valley_glacier.cfg
+# - Treynor.rti
+# - Treynor_DEM.rtg
+
+from shutil import rmtree
+from os import makedirs, listdir
+from os.path import join, dirname, exists
+from nose.tools import raises, assert_is_instance, assert_is_not_none
+from topoflow.components.ice_base import ice_component
+from . import input_dir, output_dir
+
+
+def setup_module():
+    global comp
+    comp = ice_component()
+    if exists(output_dir) is False:
+        makedirs(output_dir)
+
+
+def teardown_module():
+    parent_dir = dirname(output_dir)
+    if exists(parent_dir):
+        rmtree(parent_dir)
+
+
+def test_is_instance():
+    assert_is_instance(comp, ice_component)
+
+
+# Error using filter2d in gc2d.py, line 985.
+@raises(ValueError)
+def test_irf():
+    cfg_file = join(input_dir, 'June_20_67_ice_valley_glacier.cfg')
+
+    comp.initialize(cfg_file)
+    comp.update()
+    comp.finalize()
+
+
+def test_has_output():
+    assert_is_not_none(listdir(output_dir))

--- a/topoflow/tests/test_ice_gc2d.py
+++ b/topoflow/tests/test_ice_gc2d.py
@@ -13,7 +13,7 @@
 from shutil import rmtree
 from os import makedirs, listdir
 from os.path import join, dirname, exists
-from nose.tools import raises, assert_is_instance, assert_is_not_none
+from nose.tools import assert_is_instance, assert_is_not_none
 from topoflow.components.ice_base import ice_component as Model
 from . import input_dir, output_dir
 
@@ -35,11 +35,8 @@ def test_is_instance():
     assert_is_instance(comp, Model)
 
 
-# Error using filter2d in gc2d.py, line 985.
-@raises(ValueError)
 def test_irf():
     cfg_file = join(input_dir, 'June_20_67_ice_valley_glacier.cfg')
-
     comp.initialize(cfg_file)
     comp.update()
     comp.finalize()

--- a/topoflow/tests/test_ice_gc2d.py
+++ b/topoflow/tests/test_ice_gc2d.py
@@ -14,13 +14,13 @@ from shutil import rmtree
 from os import makedirs, listdir
 from os.path import join, dirname, exists
 from nose.tools import raises, assert_is_instance, assert_is_not_none
-from topoflow.components.ice_base import ice_component
+from topoflow.components.ice_base import ice_component as Model
 from . import input_dir, output_dir
 
 
 def setup_module():
     global comp
-    comp = ice_component()
+    comp = Model()
     if exists(output_dir) is False:
         makedirs(output_dir)
 
@@ -32,7 +32,7 @@ def teardown_module():
 
 
 def test_is_instance():
-    assert_is_instance(comp, ice_component)
+    assert_is_instance(comp, Model)
 
 
 # Error using filter2d in gc2d.py, line 985.

--- a/topoflow/tests/test_ice_gc2d.py
+++ b/topoflow/tests/test_ice_gc2d.py
@@ -14,8 +14,12 @@ from shutil import rmtree
 from os import makedirs, listdir
 from os.path import join, dirname, exists
 from nose.tools import assert_is_instance, assert_is_not_none
+from numpy.testing import assert_almost_equal
 from topoflow.components.ice_base import ice_component as Model
-from . import input_dir, output_dir
+from . import input_dir, output_dir, time_factor
+
+
+cfg_file = join(input_dir, 'June_20_67_ice_valley_glacier.cfg')
 
 
 def setup_module():
@@ -36,7 +40,6 @@ def test_is_instance():
 
 
 def test_irf():
-    cfg_file = join(input_dir, 'June_20_67_ice_valley_glacier.cfg')
     comp.initialize(cfg_file)
     comp.update()
     comp.finalize()
@@ -44,3 +47,27 @@ def test_irf():
 
 def test_has_output():
     assert_is_not_none(listdir(output_dir))
+
+
+# TODO: How will `update_frac` work with adpative time step?
+def test_update_frac():
+    time_step = comp.get_time_step()
+    frac_time = 1.0 / time_factor
+
+    comp.initialize(cfg_file)
+    comp.update_frac(frac_time)
+    end_time = comp.get_current_time()
+    comp.finalize()
+    assert_almost_equal(end_time, frac_time*time_step)
+
+
+# TODO: How will `update_until` work with adpative time step?
+def test_update_until():
+    time_step = comp.get_time_step()
+    until_time = time_step*time_factor + time_step/time_factor
+
+    comp.initialize(cfg_file)
+    comp.update_until(until_time)
+    end_time = comp.get_current_time()
+    comp.finalize()
+    assert_almost_equal(end_time, until_time)

--- a/topoflow/tests/test_infil_beven.py
+++ b/topoflow/tests/test_infil_beven.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python
+#
+# Tests the InfilBeven TopoFlow component.
+#
+# This component is incomplete.

--- a/topoflow/tests/test_infil_green_ampt.py
+++ b/topoflow/tests/test_infil_green_ampt.py
@@ -13,8 +13,12 @@ from shutil import rmtree
 from os import makedirs, listdir
 from os.path import join, dirname, exists
 from nose.tools import raises, assert_is_instance, assert_is_not_none
+from numpy.testing import assert_almost_equal
 from topoflow.components.infil_green_ampt import infil_component as Model
-from . import input_dir, output_dir
+from . import input_dir, output_dir, time_factor
+
+
+cfg_file = join(input_dir, 'June_20_67_infil_green_ampt.cfg')
 
 
 def setup_module():
@@ -35,7 +39,6 @@ def test_is_instance():
 
 
 def test_irf():
-    cfg_file = join(input_dir, 'June_20_67_infil_green_ampt.cfg')
     comp.initialize(cfg_file)
     comp.update()
     comp.finalize()
@@ -43,3 +46,25 @@ def test_irf():
 
 def test_has_output():
     assert_is_not_none(listdir(output_dir))
+
+
+def test_update_frac():
+    time_step = comp.get_time_step()
+    frac_time = 1.0 / time_factor
+
+    comp.initialize(cfg_file)
+    comp.update_frac(frac_time)
+    end_time = comp.get_current_time()
+    comp.finalize()
+    assert_almost_equal(end_time, frac_time*time_step)
+
+
+def test_update_until():
+    time_step = comp.get_time_step()
+    until_time = time_step*time_factor + time_step/time_factor
+
+    comp.initialize(cfg_file)
+    comp.update_until(until_time)
+    end_time = comp.get_current_time()
+    comp.finalize()
+    assert_almost_equal(end_time, until_time)

--- a/topoflow/tests/test_infil_green_ampt.py
+++ b/topoflow/tests/test_infil_green_ampt.py
@@ -14,13 +14,13 @@ from os import makedirs, listdir
 from os.path import join, dirname, exists
 from nose.tools import raises, assert_is_instance, assert_is_not_none
 import numpy as np
-from topoflow.components.infil_green_ampt import infil_component
+from topoflow.components.infil_green_ampt import infil_component as Model
 from . import input_dir, output_dir
 
 
 def setup_module():
     global comp
-    comp = infil_component()
+    comp = Model()
     if exists(output_dir) is False:
         makedirs(output_dir)
 
@@ -32,7 +32,7 @@ def teardown_module():
 
 
 def test_is_instance():
-    assert_is_instance(comp, infil_component)
+    assert_is_instance(comp, Model)
 
 
 def test_irf():

--- a/topoflow/tests/test_infil_green_ampt.py
+++ b/topoflow/tests/test_infil_green_ampt.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+#
+# Tests the InfilGreenAmpt TopoFlow component.
+#
+# site_prefix = 'Treynor'
+# case_prefix = 'June_20_67'
+#
+# Required input files:
+# - June_20_67_infil_green_ampt.cfg
+# - Treynor.rti
+
+from shutil import rmtree
+from os import makedirs, listdir
+from os.path import join, dirname, exists
+from nose.tools import raises, assert_is_instance, assert_is_not_none
+import numpy as np
+from topoflow.components.infil_green_ampt import infil_component
+from . import input_dir, output_dir
+
+
+def setup_module():
+    global comp
+    comp = infil_component()
+    if exists(output_dir) is False:
+        makedirs(output_dir)
+
+
+def teardown_module():
+    parent_dir = dirname(output_dir)
+    if exists(parent_dir):
+        rmtree(parent_dir)
+
+
+def test_is_instance():
+    assert_is_instance(comp, infil_component)
+
+
+def test_irf():
+    cfg_file = join(input_dir, 'June_20_67_infil_green_ampt.cfg')
+
+    # @mperignon found these attributes are needed but not provided.
+    comp.P_rain = 1
+    comp.SM = 0
+    comp.h_table = 1
+    comp.elev = 10
+
+    comp.initialize(cfg_file)
+    comp.update()
+    comp.finalize()
+
+
+def test_has_output():
+    assert_is_not_none(listdir(output_dir))

--- a/topoflow/tests/test_infil_green_ampt.py
+++ b/topoflow/tests/test_infil_green_ampt.py
@@ -37,13 +37,6 @@ def test_is_instance():
 
 def test_irf():
     cfg_file = join(input_dir, 'June_20_67_infil_green_ampt.cfg')
-
-    # @mperignon found these attributes are needed but not provided.
-    comp.P_rain = 1
-    comp.SM = 0
-    comp.h_table = 1
-    comp.elev = 10
-
     comp.initialize(cfg_file)
     comp.update()
     comp.finalize()

--- a/topoflow/tests/test_infil_green_ampt.py
+++ b/topoflow/tests/test_infil_green_ampt.py
@@ -13,7 +13,6 @@ from shutil import rmtree
 from os import makedirs, listdir
 from os.path import join, dirname, exists
 from nose.tools import raises, assert_is_instance, assert_is_not_none
-import numpy as np
 from topoflow.components.infil_green_ampt import infil_component as Model
 from . import input_dir, output_dir
 

--- a/topoflow/tests/test_infil_richards_1d.py
+++ b/topoflow/tests/test_infil_richards_1d.py
@@ -37,12 +37,6 @@ def test_is_instance():
 
 def test_irf():
     cfg_file = join(input_dir, 'June_20_67_infil_richards_1d.cfg')
-
-    # @mperignon found these attributes are needed but not provided.
-    comp.P_rain = 1
-    comp.SM = 0
-    comp.ET = 1        
-
     comp.initialize(cfg_file)
     comp.update()
     comp.finalize()

--- a/topoflow/tests/test_infil_richards_1d.py
+++ b/topoflow/tests/test_infil_richards_1d.py
@@ -13,8 +13,12 @@ from shutil import rmtree
 from os import makedirs, listdir
 from os.path import join, dirname, exists
 from nose.tools import raises, assert_is_instance, assert_is_not_none
+from numpy.testing import assert_almost_equal
 from topoflow.components.infil_richards_1D import infil_component as Model
-from . import input_dir, output_dir
+from . import input_dir, output_dir, time_factor
+
+
+cfg_file = join(input_dir, 'June_20_67_infil_richards_1d.cfg')
 
 
 def setup_module():
@@ -35,7 +39,6 @@ def test_is_instance():
 
 
 def test_irf():
-    cfg_file = join(input_dir, 'June_20_67_infil_richards_1d.cfg')
     comp.initialize(cfg_file)
     comp.update()
     comp.finalize()
@@ -43,3 +46,25 @@ def test_irf():
 
 def test_has_output():
     assert_is_not_none(listdir(output_dir))
+
+
+def test_update_frac():
+    time_step = comp.get_time_step()
+    frac_time = 1.0 / time_factor
+
+    comp.initialize(cfg_file)
+    comp.update_frac(frac_time)
+    end_time = comp.get_current_time()
+    comp.finalize()
+    assert_almost_equal(end_time, frac_time*time_step)
+
+
+def test_update_until():
+    time_step = comp.get_time_step()
+    until_time = time_step*time_factor + time_step/time_factor
+
+    comp.initialize(cfg_file)
+    comp.update_until(until_time)
+    end_time = comp.get_current_time()
+    comp.finalize()
+    assert_almost_equal(end_time, until_time)

--- a/topoflow/tests/test_infil_richards_1d.py
+++ b/topoflow/tests/test_infil_richards_1d.py
@@ -13,7 +13,6 @@ from shutil import rmtree
 from os import makedirs, listdir
 from os.path import join, dirname, exists
 from nose.tools import raises, assert_is_instance, assert_is_not_none
-import numpy as np
 from topoflow.components.infil_richards_1D import infil_component as Model
 from . import input_dir, output_dir
 

--- a/topoflow/tests/test_infil_richards_1d.py
+++ b/topoflow/tests/test_infil_richards_1d.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+#
+# Tests the InfilRichards1D TopoFlow component.
+#
+# site_prefix = 'Treynor'
+# case_prefix = 'June_20_67'
+#
+# Required input files:
+# - June_20_67_infil_richards_1d.cfg
+# - Treynor.rti
+
+from shutil import rmtree
+from os import makedirs, listdir
+from os.path import join, dirname, exists
+from nose.tools import raises, assert_is_instance, assert_is_not_none
+import numpy as np
+from topoflow.components.infil_richards_1D import infil_component
+from . import input_dir, output_dir
+
+
+def setup_module():
+    global comp
+    comp = infil_component()
+    if exists(output_dir) is False:
+        makedirs(output_dir)
+
+
+def teardown_module():
+    parent_dir = dirname(output_dir)
+    if exists(parent_dir):
+        rmtree(parent_dir)
+
+
+def test_is_instance():
+    assert_is_instance(comp, infil_component)
+
+
+def test_irf():
+    cfg_file = join(input_dir, 'June_20_67_infil_richards_1d.cfg')
+
+    # @mperignon found these attributes are needed but not provided.
+    comp.P_rain = 1
+    comp.SM = 0
+    comp.ET = 1        
+
+    comp.initialize(cfg_file)
+    comp.update()
+    comp.finalize()
+
+
+def test_has_output():
+    assert_is_not_none(listdir(output_dir))

--- a/topoflow/tests/test_infil_richards_1d.py
+++ b/topoflow/tests/test_infil_richards_1d.py
@@ -14,13 +14,13 @@ from os import makedirs, listdir
 from os.path import join, dirname, exists
 from nose.tools import raises, assert_is_instance, assert_is_not_none
 import numpy as np
-from topoflow.components.infil_richards_1D import infil_component
+from topoflow.components.infil_richards_1D import infil_component as Model
 from . import input_dir, output_dir
 
 
 def setup_module():
     global comp
-    comp = infil_component()
+    comp = Model()
     if exists(output_dir) is False:
         makedirs(output_dir)
 
@@ -32,7 +32,7 @@ def teardown_module():
 
 
 def test_is_instance():
-    assert_is_instance(comp, infil_component)
+    assert_is_instance(comp, Model)
 
 
 def test_irf():

--- a/topoflow/tests/test_infil_smith_parlange.py
+++ b/topoflow/tests/test_infil_smith_parlange.py
@@ -37,13 +37,6 @@ def test_is_instance():
 
 def test_irf():
     cfg_file = join(input_dir, 'June_20_67_infil_smith_parlange.cfg')
-
-    # @mperignon found these attributes are needed but not provided.
-    comp.P_rain = 1
-    comp.SM = 0
-    comp.h_table = 1
-    comp.elev = 10    
-
     comp.initialize(cfg_file)
     comp.update()
     comp.finalize()

--- a/topoflow/tests/test_infil_smith_parlange.py
+++ b/topoflow/tests/test_infil_smith_parlange.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+#
+# Tests the InfilSmithParlange TopoFlow component.
+#
+# site_prefix = 'Treynor'
+# case_prefix = 'June_20_67'
+#
+# Required input files:
+# - June_20_67_infil_smith_parlange.cfg
+# - Treynor.rti
+
+from shutil import rmtree
+from os import makedirs, listdir
+from os.path import join, dirname, exists
+from nose.tools import raises, assert_is_instance, assert_is_not_none
+import numpy as np
+from topoflow.components.infil_smith_parlange import infil_component
+from . import input_dir, output_dir
+
+
+def setup_module():
+    global comp
+    comp = infil_component()
+    if exists(output_dir) is False:
+        makedirs(output_dir)
+
+
+def teardown_module():
+    parent_dir = dirname(output_dir)
+    if exists(parent_dir):
+        rmtree(parent_dir)
+
+
+def test_is_instance():
+    assert_is_instance(comp, infil_component)
+
+
+def test_irf():
+    cfg_file = join(input_dir, 'June_20_67_infil_smith_parlange.cfg')
+
+    # @mperignon found these attributes are needed but not provided.
+    comp.P_rain = 1
+    comp.SM = 0
+    comp.h_table = 1
+    comp.elev = 10    
+
+    comp.initialize(cfg_file)
+    comp.update()
+    comp.finalize()
+
+
+def test_has_output():
+    assert_is_not_none(listdir(output_dir))

--- a/topoflow/tests/test_infil_smith_parlange.py
+++ b/topoflow/tests/test_infil_smith_parlange.py
@@ -13,8 +13,12 @@ from shutil import rmtree
 from os import makedirs, listdir
 from os.path import join, dirname, exists
 from nose.tools import raises, assert_is_instance, assert_is_not_none
+from numpy.testing import assert_almost_equal
 from topoflow.components.infil_smith_parlange import infil_component as Model
-from . import input_dir, output_dir
+from . import input_dir, output_dir, time_factor
+
+
+cfg_file = join(input_dir, 'June_20_67_infil_smith_parlange.cfg')
 
 
 def setup_module():
@@ -35,7 +39,6 @@ def test_is_instance():
 
 
 def test_irf():
-    cfg_file = join(input_dir, 'June_20_67_infil_smith_parlange.cfg')
     comp.initialize(cfg_file)
     comp.update()
     comp.finalize()
@@ -43,3 +46,25 @@ def test_irf():
 
 def test_has_output():
     assert_is_not_none(listdir(output_dir))
+
+
+def test_update_frac():
+    time_step = comp.get_time_step()
+    frac_time = 1.0 / time_factor
+
+    comp.initialize(cfg_file)
+    comp.update_frac(frac_time)
+    end_time = comp.get_current_time()
+    comp.finalize()
+    assert_almost_equal(end_time, frac_time*time_step)
+
+
+def test_update_until():
+    time_step = comp.get_time_step()
+    until_time = time_step*time_factor + time_step/time_factor
+
+    comp.initialize(cfg_file)
+    comp.update_until(until_time)
+    end_time = comp.get_current_time()
+    comp.finalize()
+    assert_almost_equal(end_time, until_time)

--- a/topoflow/tests/test_infil_smith_parlange.py
+++ b/topoflow/tests/test_infil_smith_parlange.py
@@ -13,7 +13,6 @@ from shutil import rmtree
 from os import makedirs, listdir
 from os.path import join, dirname, exists
 from nose.tools import raises, assert_is_instance, assert_is_not_none
-import numpy as np
 from topoflow.components.infil_smith_parlange import infil_component as Model
 from . import input_dir, output_dir
 

--- a/topoflow/tests/test_infil_smith_parlange.py
+++ b/topoflow/tests/test_infil_smith_parlange.py
@@ -14,13 +14,13 @@ from os import makedirs, listdir
 from os.path import join, dirname, exists
 from nose.tools import raises, assert_is_instance, assert_is_not_none
 import numpy as np
-from topoflow.components.infil_smith_parlange import infil_component
+from topoflow.components.infil_smith_parlange import infil_component as Model
 from . import input_dir, output_dir
 
 
 def setup_module():
     global comp
-    comp = infil_component()
+    comp = Model()
     if exists(output_dir) is False:
         makedirs(output_dir)
 
@@ -32,7 +32,7 @@ def teardown_module():
 
 
 def test_is_instance():
-    assert_is_instance(comp, infil_component)
+    assert_is_instance(comp, Model)
 
 
 def test_irf():

--- a/topoflow/tests/test_meteorology.py
+++ b/topoflow/tests/test_meteorology.py
@@ -16,13 +16,13 @@ from shutil import rmtree
 from os import makedirs, listdir
 from os.path import join, dirname, exists
 from nose.tools import assert_is_instance, assert_is_not_none
-from topoflow.components.met_base import met_component
+from topoflow.components.met_base import met_component as Model
 from . import input_dir, output_dir
 
 
 def setup_module():
     global comp
-    comp = met_component()
+    comp = Model()
     if exists(output_dir) is False:
         makedirs(output_dir)
 
@@ -34,7 +34,7 @@ def teardown_module():
 
 
 def test_is_instance():
-    assert_is_instance(comp, met_component)
+    assert_is_instance(comp, Model)
 
 
 def test_irf():

--- a/topoflow/tests/test_meteorology.py
+++ b/topoflow/tests/test_meteorology.py
@@ -16,8 +16,12 @@ from shutil import rmtree
 from os import makedirs, listdir
 from os.path import join, dirname, exists
 from nose.tools import assert_is_instance, assert_is_not_none
+from numpy.testing import assert_almost_equal
 from topoflow.components.met_base import met_component as Model
-from . import input_dir, output_dir
+from . import input_dir, output_dir, time_factor
+
+
+cfg_file = join(input_dir, 'June_20_67_meteorology.cfg')
 
 
 def setup_module():
@@ -38,7 +42,6 @@ def test_is_instance():
 
 
 def test_irf():
-    cfg_file = join(input_dir, 'June_20_67_meteorology.cfg')
     comp.initialize(cfg_file)
     comp.update()
     comp.finalize()
@@ -46,3 +49,25 @@ def test_irf():
 
 def test_has_output():
     assert_is_not_none(listdir(output_dir))
+
+
+def test_update_frac():
+    time_step = comp.get_time_step()
+    frac_time = 1.0 / time_factor
+
+    comp.initialize(cfg_file)
+    comp.update_frac(frac_time)
+    end_time = comp.get_current_time()
+    comp.finalize()
+    assert_almost_equal(end_time, frac_time*time_step)
+
+
+def test_update_until():
+    time_step = comp.get_time_step()
+    until_time = time_step*time_factor + time_step/time_factor
+
+    comp.initialize(cfg_file)
+    comp.update_until(until_time)
+    end_time = comp.get_current_time()
+    comp.finalize()
+    assert_almost_equal(end_time, until_time)

--- a/topoflow/tests/test_meteorology.py
+++ b/topoflow/tests/test_meteorology.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+#
+# Tests the Meteorology TopoFlow component.
+#
+# site_prefix = 'Treynor'
+# case_prefix = 'June_20_67'
+#
+# Required input files:
+# - June_20_67_meteorology.cfg
+# - Treynor.rti
+# - June_20_67_rain_rates.txt
+# - Treynor_slope.bin
+# - Treynor_aspect.bin
+
+from shutil import rmtree
+from os import makedirs, listdir
+from os.path import join, dirname, exists
+from nose.tools import assert_is_instance, assert_is_not_none
+from topoflow.components.met_base import met_component
+from . import input_dir, output_dir
+
+
+def setup_module():
+    global comp
+    comp = met_component()
+    if exists(output_dir) is False:
+        makedirs(output_dir)
+
+
+def teardown_module():
+    parent_dir = dirname(output_dir)
+    if exists(parent_dir):
+        rmtree(parent_dir)
+
+
+def test_is_instance():
+    assert_is_instance(comp, met_component)
+
+
+def test_irf():
+    cfg_file = join(input_dir, 'June_20_67_meteorology.cfg')
+
+    # This attributes is needed but not provided.
+    comp.h_snow = 1
+
+    comp.initialize(cfg_file)
+    comp.update()
+    comp.finalize()
+
+
+def test_has_output():
+    assert_is_not_none(listdir(output_dir))

--- a/topoflow/tests/test_meteorology.py
+++ b/topoflow/tests/test_meteorology.py
@@ -39,10 +39,6 @@ def test_is_instance():
 
 def test_irf():
     cfg_file = join(input_dir, 'June_20_67_meteorology.cfg')
-
-    # This attributes is needed but not provided.
-    comp.h_snow = 1
-
     comp.initialize(cfg_file)
     comp.update()
     comp.finalize()

--- a/topoflow/tests/test_satzone_darcy_layers.py
+++ b/topoflow/tests/test_satzone_darcy_layers.py
@@ -37,10 +37,6 @@ def test_is_instance():
 
 def test_irf():
     cfg_file = join(input_dir, 'June_20_67_satzone_darcy_layers.cfg')
-
-    # @mperignon found these attributes are needed but not provided.
-    comp.Rg = 1
-
     comp.initialize(cfg_file)
     comp.update()
     comp.finalize()

--- a/topoflow/tests/test_satzone_darcy_layers.py
+++ b/topoflow/tests/test_satzone_darcy_layers.py
@@ -50,9 +50,20 @@ def test_has_output():
     assert_is_not_none(listdir(output_dir))
 
 
+def test_update_frac():
+    time_step = comp.get_time_step()
+    frac_time = 1.0 / time_factor
+
+    comp.initialize(cfg_file)
+    comp.update_frac(frac_time)
+    end_time = comp.get_current_time()
+    comp.finalize()
+    assert_almost_equal(end_time, frac_time*time_step)
+
+
 def test_update_until():
     time_step = comp.get_time_step()
-    until_time = time_step * time_factor
+    until_time = time_step*time_factor + time_step/time_factor
 
     comp.initialize(cfg_file)
     comp.update_until(until_time)

--- a/topoflow/tests/test_satzone_darcy_layers.py
+++ b/topoflow/tests/test_satzone_darcy_layers.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+#
+# Tests the SatZoneDarcyLayers TopoFlow component.
+#
+# site_prefix = 'Treynor'
+# case_prefix = 'June_20_67'
+#
+# Required input files:
+# - June_20_67_satzone_darcy_layers.cfg
+# - Treynor.rti
+# - Treynor_DEM.rtg
+
+from shutil import rmtree
+from os import makedirs, listdir
+from os.path import join, dirname, exists
+from nose.tools import assert_is_instance, assert_is_not_none
+from topoflow.components.satzone_darcy_layers import satzone_component
+from . import input_dir, output_dir
+
+
+def setup_module():
+    global comp
+    comp = satzone_component()
+    if exists(output_dir) is False:
+        makedirs(output_dir)
+
+
+def teardown_module():
+    parent_dir = dirname(output_dir)
+    if exists(parent_dir):
+        rmtree(parent_dir)
+
+
+def test_is_instance():
+    assert_is_instance(comp, satzone_component)
+
+
+def test_irf():
+    cfg_file = join(input_dir, 'June_20_67_satzone_darcy_layers.cfg')
+
+    comp.initialize(cfg_file)
+    comp.update()
+    comp.finalize()
+
+
+def test_has_output():
+    assert_is_not_none(listdir(output_dir))

--- a/topoflow/tests/test_satzone_darcy_layers.py
+++ b/topoflow/tests/test_satzone_darcy_layers.py
@@ -38,6 +38,9 @@ def test_is_instance():
 def test_irf():
     cfg_file = join(input_dir, 'June_20_67_satzone_darcy_layers.cfg')
 
+    # @mperignon found these attributes are needed but not provided.
+    comp.Rg = 1
+
     comp.initialize(cfg_file)
     comp.update()
     comp.finalize()

--- a/topoflow/tests/test_satzone_darcy_layers.py
+++ b/topoflow/tests/test_satzone_darcy_layers.py
@@ -14,8 +14,13 @@ from shutil import rmtree
 from os import makedirs, listdir
 from os.path import join, dirname, exists
 from nose.tools import assert_is_instance, assert_is_not_none
+from numpy.testing import assert_almost_equal
 from topoflow.components.satzone_darcy_layers import satzone_component as Model
 from . import input_dir, output_dir
+
+
+cfg_file = join(input_dir, 'June_20_67_satzone_darcy_layers.cfg')
+time_factor = 5.0
 
 
 def setup_module():
@@ -36,7 +41,6 @@ def test_is_instance():
 
 
 def test_irf():
-    cfg_file = join(input_dir, 'June_20_67_satzone_darcy_layers.cfg')
     comp.initialize(cfg_file)
     comp.update()
     comp.finalize()
@@ -44,3 +48,14 @@ def test_irf():
 
 def test_has_output():
     assert_is_not_none(listdir(output_dir))
+
+
+def test_update_until():
+    time_step = comp.get_time_step()
+    until_time = time_step * time_factor
+
+    comp.initialize(cfg_file)
+    comp.update_until(until_time)
+    end_time = comp.get_current_time()
+    comp.finalize()
+    assert_almost_equal(end_time, until_time)

--- a/topoflow/tests/test_satzone_darcy_layers.py
+++ b/topoflow/tests/test_satzone_darcy_layers.py
@@ -16,11 +16,10 @@ from os.path import join, dirname, exists
 from nose.tools import assert_is_instance, assert_is_not_none
 from numpy.testing import assert_almost_equal
 from topoflow.components.satzone_darcy_layers import satzone_component as Model
-from . import input_dir, output_dir
+from . import input_dir, output_dir, time_factor
 
 
 cfg_file = join(input_dir, 'June_20_67_satzone_darcy_layers.cfg')
-time_factor = 5.0
 
 
 def setup_module():

--- a/topoflow/tests/test_satzone_darcy_layers.py
+++ b/topoflow/tests/test_satzone_darcy_layers.py
@@ -14,13 +14,13 @@ from shutil import rmtree
 from os import makedirs, listdir
 from os.path import join, dirname, exists
 from nose.tools import assert_is_instance, assert_is_not_none
-from topoflow.components.satzone_darcy_layers import satzone_component
+from topoflow.components.satzone_darcy_layers import satzone_component as Model
 from . import input_dir, output_dir
 
 
 def setup_module():
     global comp
-    comp = satzone_component()
+    comp = Model()
     if exists(output_dir) is False:
         makedirs(output_dir)
 
@@ -32,7 +32,7 @@ def teardown_module():
 
 
 def test_is_instance():
-    assert_is_instance(comp, satzone_component)
+    assert_is_instance(comp, Model)
 
 
 def test_irf():

--- a/topoflow/tests/test_snow_degree_day.py
+++ b/topoflow/tests/test_snow_degree_day.py
@@ -13,13 +13,13 @@ from shutil import rmtree
 from os import makedirs, listdir
 from os.path import join, dirname, exists
 from nose.tools import assert_is_instance, assert_is_not_none
-from topoflow.components.snow_degree_day import snow_component
+from topoflow.components.snow_degree_day import snow_component as Model
 from . import input_dir, output_dir
 
 
 def setup_module():
     global comp
-    comp = snow_component()
+    comp = Model()
     if exists(output_dir) is False:
         makedirs(output_dir)
 
@@ -31,7 +31,7 @@ def teardown_module():
 
 
 def test_is_instance():
-    assert_is_instance(comp, snow_component)
+    assert_is_instance(comp, Model)
 
 
 def test_irf():

--- a/topoflow/tests/test_snow_degree_day.py
+++ b/topoflow/tests/test_snow_degree_day.py
@@ -36,12 +36,6 @@ def test_is_instance():
 
 def test_irf():
     cfg_file = join(input_dir, 'June_20_67_snow_degree_day.cfg')
-
-    # @mperignon found these attributes are needed but not provided.
-    comp.P_snow = 1
-    comp.rho_H2O = 1000
-    comp.T_air = 10
-    
     comp.initialize(cfg_file)
     comp.update()
     comp.finalize()

--- a/topoflow/tests/test_snow_degree_day.py
+++ b/topoflow/tests/test_snow_degree_day.py
@@ -13,8 +13,12 @@ from shutil import rmtree
 from os import makedirs, listdir
 from os.path import join, dirname, exists
 from nose.tools import assert_is_instance, assert_is_not_none
+from numpy.testing import assert_almost_equal
 from topoflow.components.snow_degree_day import snow_component as Model
-from . import input_dir, output_dir
+from . import input_dir, output_dir, time_factor
+
+
+cfg_file = join(input_dir, 'June_20_67_snow_degree_day.cfg')
 
 
 def setup_module():
@@ -35,7 +39,6 @@ def test_is_instance():
 
 
 def test_irf():
-    cfg_file = join(input_dir, 'June_20_67_snow_degree_day.cfg')
     comp.initialize(cfg_file)
     comp.update()
     comp.finalize()
@@ -43,3 +46,25 @@ def test_irf():
 
 def test_has_output():
     assert_is_not_none(listdir(output_dir))
+
+
+def test_update_frac():
+    time_step = comp.get_time_step()
+    frac_time = 1.0 / time_factor
+
+    comp.initialize(cfg_file)
+    comp.update_frac(frac_time)
+    end_time = comp.get_current_time()
+    comp.finalize()
+    assert_almost_equal(end_time, frac_time*time_step)
+
+
+def test_update_until():
+    time_step = comp.get_time_step()
+    until_time = time_step*time_factor + time_step/time_factor
+
+    comp.initialize(cfg_file)
+    comp.update_until(until_time)
+    end_time = comp.get_current_time()
+    comp.finalize()
+    assert_almost_equal(end_time, until_time)

--- a/topoflow/tests/test_snow_degree_day.py
+++ b/topoflow/tests/test_snow_degree_day.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+#
+# Tests the SnowDegreeDay TopoFlow component.
+#
+# site_prefix = 'Treynor'
+# case_prefix = 'June_20_67'
+#
+# Required input files:
+# - June_20_67_snow_degree_day.cfg
+# - Treynor.rti
+
+from shutil import rmtree
+from os import makedirs, listdir
+from os.path import join, dirname, exists
+from nose.tools import assert_is_instance, assert_is_not_none
+from topoflow.components.snow_degree_day import snow_component
+from . import input_dir, output_dir
+
+
+def setup_module():
+    global comp
+    comp = snow_component()
+    if exists(output_dir) is False:
+        makedirs(output_dir)
+
+
+def teardown_module():
+    parent_dir = dirname(output_dir)
+    if exists(parent_dir):
+        rmtree(parent_dir)
+
+
+def test_is_instance():
+    assert_is_instance(comp, snow_component)
+
+
+def test_irf():
+    cfg_file = join(input_dir, 'June_20_67_snow_degree_day.cfg')
+
+    # @mperignon found these attributes are needed but not provided.
+    comp.P_snow = 1
+    comp.rho_H2O = 1000
+    comp.T_air = 10
+    
+    comp.initialize(cfg_file)
+    comp.update()
+    comp.finalize()
+
+
+def test_has_output():
+    assert_is_not_none(listdir(output_dir))

--- a/topoflow/tests/test_snow_energy_balance.py
+++ b/topoflow/tests/test_snow_energy_balance.py
@@ -36,16 +36,6 @@ def test_is_instance():
 
 def test_irf():
     cfg_file = join(input_dir, 'June_20_67_snow_energy_balance.cfg')
-
-    # @mperignon found these attributes are needed but not provided.
-    comp.P_snow = 1
-    comp.rho_H2O = 1000
-    comp.rho_air = 1
-    comp.Cp_air = 1    
-    comp.T_air = 10
-    comp.T_surf = 20    
-    comp.Q_sum = 1
-    
     comp.initialize(cfg_file)
     comp.update()
     comp.finalize()

--- a/topoflow/tests/test_snow_energy_balance.py
+++ b/topoflow/tests/test_snow_energy_balance.py
@@ -13,8 +13,12 @@ from shutil import rmtree
 from os import makedirs, listdir
 from os.path import join, dirname, exists
 from nose.tools import assert_is_instance, assert_is_not_none
+from numpy.testing import assert_almost_equal
 from topoflow.components.snow_energy_balance import snow_component as Model
-from . import input_dir, output_dir
+from . import input_dir, output_dir, time_factor
+
+
+cfg_file = join(input_dir, 'June_20_67_snow_energy_balance.cfg')
 
 
 def setup_module():
@@ -35,7 +39,6 @@ def test_is_instance():
 
 
 def test_irf():
-    cfg_file = join(input_dir, 'June_20_67_snow_energy_balance.cfg')
     comp.initialize(cfg_file)
     comp.update()
     comp.finalize()
@@ -43,3 +46,25 @@ def test_irf():
 
 def test_has_output():
     assert_is_not_none(listdir(output_dir))
+
+
+def test_update_frac():
+    time_step = comp.get_time_step()
+    frac_time = 1.0 / time_factor
+
+    comp.initialize(cfg_file)
+    comp.update_frac(frac_time)
+    end_time = comp.get_current_time()
+    comp.finalize()
+    assert_almost_equal(end_time, frac_time*time_step)
+
+
+def test_update_until():
+    time_step = comp.get_time_step()
+    until_time = time_step*time_factor + time_step/time_factor
+
+    comp.initialize(cfg_file)
+    comp.update_until(until_time)
+    end_time = comp.get_current_time()
+    comp.finalize()
+    assert_almost_equal(end_time, until_time)

--- a/topoflow/tests/test_snow_energy_balance.py
+++ b/topoflow/tests/test_snow_energy_balance.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+#
+# Tests the SnowEnergyBalance TopoFlow component.
+#
+# site_prefix = 'Treynor'
+# case_prefix = 'June_20_67'
+#
+# Required input files:
+# - June_20_67_snow_energy_balance.cfg
+# - Treynor.rti
+
+from shutil import rmtree
+from os import makedirs, listdir
+from os.path import join, dirname, exists
+from nose.tools import assert_is_instance, assert_is_not_none
+from topoflow.components.snow_energy_balance import snow_component
+from . import input_dir, output_dir
+
+
+def setup_module():
+    global comp
+    comp = snow_component()
+    if exists(output_dir) is False:
+        makedirs(output_dir)
+
+
+def teardown_module():
+    parent_dir = dirname(output_dir)
+    if exists(parent_dir):
+        rmtree(parent_dir)
+
+
+def test_is_instance():
+    assert_is_instance(comp, snow_component)
+
+
+def test_irf():
+    cfg_file = join(input_dir, 'June_20_67_snow_energy_balance.cfg')
+
+    # @mperignon found these attributes are needed but not provided.
+    comp.P_snow = 1
+    comp.rho_H2O = 1000
+    comp.rho_air = 1
+    comp.Cp_air = 1    
+    comp.T_air = 10
+    comp.T_surf = 20    
+    comp.Q_sum = 1
+    
+    comp.initialize(cfg_file)
+    comp.update()
+    comp.finalize()
+
+
+def test_has_output():
+    assert_is_not_none(listdir(output_dir))

--- a/topoflow/tests/test_snow_energy_balance.py
+++ b/topoflow/tests/test_snow_energy_balance.py
@@ -13,13 +13,13 @@ from shutil import rmtree
 from os import makedirs, listdir
 from os.path import join, dirname, exists
 from nose.tools import assert_is_instance, assert_is_not_none
-from topoflow.components.snow_energy_balance import snow_component
+from topoflow.components.snow_energy_balance import snow_component as Model
 from . import input_dir, output_dir
 
 
 def setup_module():
     global comp
-    comp = snow_component()
+    comp = Model()
     if exists(output_dir) is False:
         makedirs(output_dir)
 
@@ -31,7 +31,7 @@ def teardown_module():
 
 
 def test_is_instance():
-    assert_is_instance(comp, snow_component)
+    assert_is_instance(comp, Model)
 
 
 def test_irf():

--- a/topoflow/tests/test_topoflow_driver.py
+++ b/topoflow/tests/test_topoflow_driver.py
@@ -14,13 +14,13 @@ from os import makedirs, listdir
 from os.path import join, dirname, exists
 import numpy as np
 from nose.tools import assert_is_instance, assert_is_not_none
-from topoflow.components.topoflow_driver import topoflow_driver
+from topoflow.components.topoflow_driver import topoflow_driver as Model
 from . import input_dir, output_dir
 
 
 def setup_module():
     global comp
-    comp = topoflow_driver()
+    comp = Model()
     if exists(output_dir) is False:
         makedirs(output_dir)
 
@@ -32,7 +32,7 @@ def teardown_module():
 
 
 def test_is_instance():
-    assert_is_instance(comp, topoflow_driver)
+    assert_is_instance(comp, Model)
 
 
 def test_irf():

--- a/topoflow/tests/test_topoflow_driver.py
+++ b/topoflow/tests/test_topoflow_driver.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+#
+# Tests the TopoFlow driver component.
+#
+# site_prefix = 'Treynor'
+# case_prefix = 'June_20_67'
+#
+# Required input files:
+# - June_20_67_topoflow.cfg
+# - Treynor.rti
+
+from shutil import rmtree
+from os import makedirs, listdir
+from os.path import join, dirname, exists
+import numpy as np
+from nose.tools import assert_is_instance, assert_is_not_none
+from topoflow.components.topoflow_driver import topoflow_driver
+from . import input_dir, output_dir
+
+
+def setup_module():
+    global comp
+    comp = topoflow_driver()
+    if exists(output_dir) is False:
+        makedirs(output_dir)
+
+
+def teardown_module():
+    parent_dir = dirname(output_dir)
+    if exists(parent_dir):
+        rmtree(parent_dir)
+
+
+def test_is_instance():
+    assert_is_instance(comp, topoflow_driver)
+
+
+def test_irf():
+    cfg_file = join(input_dir, 'June_20_67_topoflow.cfg')
+
+    # @mperignon and @mdpiper found these attributes are needed but not provided.
+    comp.Q_outlet = np.array(1)
+    comp.Q_peak = 1
+    comp.T_peak = 1
+    comp.u_peak = 1
+    comp.Tu_peak = 1
+    comp.d_peak = 1
+    comp.Td_peak = 1
+    comp.P_max = 1
+    comp.vol_P = 1
+    comp.vol_Q = 1
+    comp.vol_SM = 1
+    comp.vol_MR = 1
+    comp.vol_ET = 1
+    comp.vol_IN = 1
+    comp.vol_Rg = 1
+    comp.vol_GW = 1
+    comp.vol_R = 1
+    comp.Q_min = 0
+    comp.Q_max = 1
+    comp.u_min = 0
+    comp.u_max = 1
+    comp.d_min = 0
+    comp.d_max = 1
+
+    comp.initialize(cfg_file)
+    comp.update()
+    comp.finalize()
+
+
+def test_has_output():
+    assert_is_not_none(listdir(output_dir))

--- a/topoflow/utils/BMI_base.py
+++ b/topoflow/utils/BMI_base.py
@@ -1825,7 +1825,7 @@ class BMI_component:
             ## print 'cfg_directory =', cfg_directory
             self.cfg_directory = cfg_directory
             if (self.in_directory[0] == '.'):
-                self.in_directory = self.cfg_directory
+                self.in_directory = os.path.abspath('.')
                 
         #------------------------------------------------------
         # Expand path abbreviations: "." and "..", but NOT

--- a/topoflow/utils/BMI_base.py
+++ b/topoflow/utils/BMI_base.py
@@ -914,25 +914,32 @@ class BMI_component:
         """Advance model state by one time step."""
         pass
 
+    def update_frac(self, time_frac):
+        """Update model by a fraction of a time step.
+
+        Parameters
+        ----------
+        time_frac : float
+            Fraction of a time step.
+        """
+        time_step = self.get_time_step()
+        self.dt = time_frac * time_step
+        self.update()
+        self.dt = time_step
+
     def update_until(self, then):
         """Advance model state until the given time.
 
         Parameters
         ----------
         then : float
-          A model time value.
+            Time to run model until.
         """
-        pass
+        n_steps = (then - self.get_current_time()) / self.get_time_step()
 
-    def update_frac(self, time_frac):
-        """Advance model state by a fraction of a time step.
-
-        Parameters
-        ----------
-        time_frac : float
-          A fraction of a model time step value.
-        """
-        pass
+        for _ in xrange(int(n_steps)):
+            self.update()
+        self.update_frac(n_steps - int(n_steps))
 
     def finalize(self):
 

--- a/topoflow/utils/BMI_base.py
+++ b/topoflow/utils/BMI_base.py
@@ -909,6 +909,31 @@ class BMI_component:
 ##        
 ##    #   update()
     #-------------------------------------------------------------------
+
+    def update(self):
+        """Advance model state by one time step."""
+        pass
+
+    def update_until(self, then):
+        """Advance model state until the given time.
+
+        Parameters
+        ----------
+        then : float
+          A model time value.
+        """
+        pass
+
+    def update_frac(self, time_frac):
+        """Advance model state by a fraction of a time step.
+
+        Parameters
+        ----------
+        time_frac : float
+          A fraction of a model time step value.
+        """
+        pass
+
     def finalize(self):
 
         self.status = 'finalizing'  # (OpenMI 2.0 convention)


### PR DESCRIPTION
Here's a list of modifications:
- Updated the **.bmi.yaml** file + added subdirectories to **.bmi/** for each of the TopoFlow components. This could've been included in #1, but I wanted to make sure the idea was sound before I extended it to all the components. Note that the **parameters.yaml** files are only stubbed out; they'll have to be filled in later.
- Set default attributes for several components to allow them to run in standalone mode. I tried to make educated guesses for the values, but it would be good to run these changes past @peckhams.
- Implemented `update_frac` and `update_until` methods in the superclass `BMI_component`. They work for all but two components: IceGC2D, which has an adaptive time step, and EvapReadFile, which is missing its file to read. The `update_until` method is used by the CMI.
- Added a set of `nose` unit tests for each of the components in the `topoflow.tests` subpackage. They use the files in **topoflow/examples/Treynor_Iowa**. They test IRF and `update*` methods.
